### PR TITLE
TOC can be sorted alphabeticaly, to behave like an index

### DIFF
--- a/flexmark-ext-toc/src/main/java/com/vladsch/flexmark/ext/toc/SimTocExtension.java
+++ b/flexmark-ext-toc/src/main/java/com/vladsch/flexmark/ext/toc/SimTocExtension.java
@@ -35,6 +35,7 @@ public class SimTocExtension implements Parser.ParserExtension, HtmlRenderer.Htm
     public static final DataKey<Integer> LEVELS = TocExtension.LEVELS;
     public static final DataKey<Boolean> IS_TEXT_ONLY = TocExtension.IS_TEXT_ONLY;
     public static final DataKey<Boolean> IS_NUMBERED = TocExtension.IS_NUMBERED;
+    public static final DataKey<Boolean> IS_SORT_ALPHA = TocExtension.IS_SORT_ALPHA;
     public static final DataKey<Boolean> IS_HTML = new DataKey<>("IS_HTML", false);
     public static final DataKey<Integer> TITLE_LEVEL = new DataKey<>("TITLE_LEVEL", TocOptions.DEFAULT_TITLE_LEVEL);
     public static final DataKey<String> TITLE = new DataKey<>("TITLE", TocOptions.DEFAULT_TITLE);

--- a/flexmark-ext-toc/src/main/java/com/vladsch/flexmark/ext/toc/TocExtension.java
+++ b/flexmark-ext-toc/src/main/java/com/vladsch/flexmark/ext/toc/TocExtension.java
@@ -30,6 +30,7 @@ public class TocExtension implements Parser.ParserExtension, HtmlRenderer.HtmlRe
     public static final DataKey<Integer> LEVELS = new DataKey<>("LEVELS", TocOptions.DEFAULT_LEVELS);
     public static final DataKey<Boolean> IS_TEXT_ONLY = new DataKey<>("IS_TEXT_ONLY", false);
     public static final DataKey<Boolean> IS_NUMBERED = new DataKey<>("IS_NUMBERED", false);
+    public static final DataKey<Boolean> IS_SORT_ALPHA = new DataKey<>("IS_SORT_ALPHA", false);
 
     private TocExtension() {
     }

--- a/flexmark-ext-toc/src/main/java/com/vladsch/flexmark/ext/toc/internal/SimTocNodeRenderer.java
+++ b/flexmark-ext-toc/src/main/java/com/vladsch/flexmark/ext/toc/internal/SimTocNodeRenderer.java
@@ -88,7 +88,16 @@ public class SimTocNodeRenderer implements NodeRenderer {
 
     private void renderTocHeaders(NodeRendererContext context, HtmlWriter html, Node node, List<Heading> headings, TocOptions options) {
         List<Heading> filteredHeadings = TocUtils.filteredHeadings(headings, options);
-        List<String> headingTexts = TocUtils.htmlHeaderTexts(context, filteredHeadings, options);
-        TocUtils.renderHtmlToc(html, context.getHtmlOptions().sourcePositionAttribute.isEmpty() ? BasedSequence.NULL : node.getChars(), filteredHeadings, headingTexts, options);
+        List<Heading> sortedHeadings = sort(context, filteredHeadings, options);
+        List<String> headingTexts = TocUtils.htmlHeaderTexts(context, sortedHeadings, options);
+        TocUtils.renderHtmlToc(html, context.getHtmlOptions().sourcePositionAttribute.isEmpty() ? BasedSequence.NULL : node.getChars(), sortedHeadings, headingTexts, options);
     }
+
+    private List<Heading> sort(NodeRendererContext context, List<Heading> filteredHeadings, TocOptions options) {
+        if (options.sortAlpha) {
+            return TocUtils.sortAlpha(context, filteredHeadings, options);
+        }
+        return filteredHeadings;
+    }
+
 }

--- a/flexmark-ext-toc/src/main/java/com/vladsch/flexmark/ext/toc/internal/TocNodeRenderer.java
+++ b/flexmark-ext-toc/src/main/java/com/vladsch/flexmark/ext/toc/internal/TocNodeRenderer.java
@@ -53,7 +53,16 @@ public class TocNodeRenderer implements NodeRenderer {
 
     private void renderTocHeaders(NodeRendererContext context, HtmlWriter html, Node node, List<Heading> headings, TocOptions options) {
         List<Heading> filteredHeadings = TocUtils.filteredHeadings(headings, options);
-        List<String> headingTexts = TocUtils.htmlHeaderTexts(context, filteredHeadings, options);
-        TocUtils.renderHtmlToc(html, context.getHtmlOptions().sourcePositionAttribute.isEmpty() ? BasedSequence.NULL : node.getChars(), filteredHeadings, headingTexts, options);
+        List<Heading> sortedHeadings = sort(context, filteredHeadings, options);
+        List<String> headingTexts = TocUtils.htmlHeaderTexts(context, sortedHeadings, options);
+        TocUtils.renderHtmlToc(html, context.getHtmlOptions().sourcePositionAttribute.isEmpty() ? BasedSequence.NULL : node.getChars(), sortedHeadings, headingTexts, options);
     }
+
+    private List<Heading> sort(NodeRendererContext context, List<Heading> filteredHeadings, TocOptions options) {
+        if (options.sortAlpha) {
+            return TocUtils.sortAlpha(context, filteredHeadings, options);
+        }
+        return filteredHeadings;
+    }
+
 }

--- a/flexmark-ext-toc/src/main/java/com/vladsch/flexmark/ext/toc/internal/TocOptions.java
+++ b/flexmark-ext-toc/src/main/java/com/vladsch/flexmark/ext/toc/internal/TocOptions.java
@@ -26,6 +26,7 @@ public class TocOptions {
     public static final String DEFAULT_TITLE = "Table of Contents";
     public static final int DEFAULT_TITLE_LEVEL = 1;
     public static final int VALID_LEVELS = 0x7e;
+    public static final boolean SORT_ALPHA = false;
 
     public final int levels;
     public final boolean isHtml;
@@ -34,10 +35,11 @@ public class TocOptions {
     public final int titleLevel;
     public final String title;
     public final int rawTitleLevel;
+    public final boolean sortAlpha;
     public final String rawTitle;
 
     public TocOptions() {
-        this(DEFAULT_LEVELS, false, false, false, DEFAULT_TITLE_LEVEL, DEFAULT_TITLE);
+        this(DEFAULT_LEVELS, false, false, false, DEFAULT_TITLE_LEVEL, DEFAULT_TITLE, SORT_ALPHA);
     }
 
     public TocOptions(DataHolder options) {
@@ -47,17 +49,23 @@ public class TocOptions {
                 options.get(SimTocExtension.IS_TEXT_ONLY),
                 options.get(SimTocExtension.IS_NUMBERED),
                 options.get(SimTocExtension.TITLE_LEVEL),
-                options.get(SimTocExtension.TITLE)
+                options.get(SimTocExtension.TITLE),
+                options.get(SimTocExtension.IS_SORT_ALPHA)
         );
     }
 
     public TocOptions(int levels, boolean isHtml, boolean isTextOnly, boolean isNumbered, int titleLevel, String title) {
+        this(levels, isHtml, isTextOnly, isNumbered, titleLevel, title, SORT_ALPHA);
+    }
+
+    public TocOptions(int levels, boolean isHtml, boolean isTextOnly, boolean isNumbered, int titleLevel, String title, boolean sortAlpha) {
         this.levels = levels & VALID_LEVELS;
         this.isHtml = isHtml;
         this.isTextOnly = isTextOnly;
         this.isNumbered = isNumbered;
         this.rawTitle = title == null ? "" : title;
         this.rawTitleLevel = titleLevel;
+        this.sortAlpha = sortAlpha;
         if (!rawTitle.isEmpty()) {
             int markers = SubSequence.of(rawTitle.trim()).countLeading("#");
             if (markers >= 1 && markers <= 6) titleLevel = markers;
@@ -73,19 +81,20 @@ public class TocOptions {
     }
 
     // @Formatter:off
-    public TocOptions withLevels(int levels)                { return new TocOptions(levels, isHtml, isTextOnly, isNumbered, titleLevel, title); }
-    public TocOptions withIsHtml(boolean isHtml)            { return new TocOptions(levels, isHtml, isTextOnly, isNumbered, titleLevel, title); }
-    public TocOptions withIsTextOnly(boolean isTextOnly)    { return new TocOptions(levels, isHtml, isTextOnly, isNumbered, titleLevel, title); }
-    public TocOptions withIsNumbered(boolean isNumbered)    { return new TocOptions(levels, isHtml, isTextOnly, isNumbered, titleLevel, title); }
-    public TocOptions withTitleLevel(int titleLevel)        { return new TocOptions(levels, isHtml, isTextOnly, isNumbered, titleLevel, title); }
-    public TocOptions withTitle( String title)              { return new TocOptions(levels, isHtml, isTextOnly, isNumbered, titleLevel, title); }
-    public TocOptions withRawTitleLevel(int titleLevel)     { return new TocOptions(levels, isHtml, isTextOnly, isNumbered, titleLevel, title); }
-    public TocOptions withRawTitle( String title)           { return new TocOptions(levels, isHtml, isTextOnly, isNumbered, titleLevel, title); }
+    public TocOptions withLevels(int levels)                { return new TocOptions(levels, isHtml, isTextOnly, isNumbered, titleLevel, title, sortAlpha); }
+    public TocOptions withIsHtml(boolean isHtml)            { return new TocOptions(levels, isHtml, isTextOnly, isNumbered, titleLevel, title, sortAlpha); }
+    public TocOptions withIsTextOnly(boolean isTextOnly)    { return new TocOptions(levels, isHtml, isTextOnly, isNumbered, titleLevel, title, sortAlpha); }
+    public TocOptions withIsNumbered(boolean isNumbered)    { return new TocOptions(levels, isHtml, isTextOnly, isNumbered, titleLevel, title, sortAlpha); }
+    public TocOptions withTitleLevel(int titleLevel)        { return new TocOptions(levels, isHtml, isTextOnly, isNumbered, titleLevel, title, sortAlpha); }
+    public TocOptions withTitle( String title)              { return new TocOptions(levels, isHtml, isTextOnly, isNumbered, titleLevel, title, sortAlpha); }
+    public TocOptions withRawTitleLevel(int titleLevel)     { return new TocOptions(levels, isHtml, isTextOnly, isNumbered, titleLevel, title, sortAlpha); }
+    public TocOptions withRawTitle( String title)           { return new TocOptions(levels, isHtml, isTextOnly, isNumbered, titleLevel, title, sortAlpha); }
+    public TocOptions withIsSortAlpha(boolean sortAlpha)    { return new TocOptions(levels, isHtml, isTextOnly, isNumbered, titleLevel, title, sortAlpha); }
     // @Formatter:on
 
     public TocOptions withLevelList(int... levelList) {
         int levels = getLevels(levelList);
-        return new TocOptions(levels, isHtml, isTextOnly, isNumbered, titleLevel, title);
+        return new TocOptions(levels, isHtml, isTextOnly, isNumbered, titleLevel, title, sortAlpha);
     }
 
     public static int getLevels(int... levelList) {


### PR DESCRIPTION
Hi,

first of all, thank you for your work, it helped me a lot!

I am suggesting this patch, because of a specific use case I encountered:
I needed to create a index of the document, where items are sorted alphabeticaly, followed by their corresponding page (for this I use flying-saucer and `@page` css instructions, but it's unrelated to this patch).

As far as I understood, the behavior I want is very similar to the TOC extension.
So, instead of duplicating the code into a new extension, I started hacking a bit the TOC code.
I added a new option, to allow sorting headers by their titles.

Please let me know if I this approach is incorrect, and what I should be changed in this patch to make it mergeable.

Thank you again