### PR TITLE
Add target attribute support to ResolvedLink and updates to the associated core renderer code.

### DIFF
--- a/flexmark/pom.xml
+++ b/flexmark/pom.xml
@@ -10,6 +10,7 @@
     <artifactId>flexmark</artifactId>
     <name>flexmark-java core</name>
     <description>Core of flexmark-java (implementation of CommonMark for parsing markdown and rendering to HTML)</description>
+    <version>0.19.9_SAA-SNAPSHOT</version>
 
     <dependencies>
         <dependency>

--- a/flexmark/src/main/java/com/vladsch/flexmark/html/renderer/CoreNodeRenderer.java
+++ b/flexmark/src/main/java/com/vladsch/flexmark/html/renderer/CoreNodeRenderer.java
@@ -669,6 +669,9 @@ public class CoreNodeRenderer implements NodeRenderer {
             ResolvedLink resolvedLink = context.resolveLink(LinkType.LINK, node.getUrl().unescape(), null);
 
             html.attr("href", resolvedLink.getUrl());
+            if (resolvedLink.getTarget() != null) {
+                html.attr("target", resolvedLink.getTarget());
+            }
             if (node.getTitle().isNotNull()) {
                 html.attr("title", node.getTitle().unescape());
             }
@@ -758,6 +761,9 @@ public class CoreNodeRenderer implements NodeRenderer {
                 context.renderChildren(node);
             } else {
                 html.attr("href", resolvedLink.getUrl());
+                if (resolvedLink.getTarget() != null) {
+                    html.attr("target", resolvedLink.getTarget());
+                }
                 if (resolvedLink.getTitle() != null) {
                     html.attr("title", resolvedLink.getTitle());
                 }

--- a/flexmark/src/main/java/com/vladsch/flexmark/html/renderer/ResolvedLink.java
+++ b/flexmark/src/main/java/com/vladsch/flexmark/html/renderer/ResolvedLink.java
@@ -5,6 +5,7 @@ public class ResolvedLink {
     private final String myUrl;
     private final String myTitle;
     private final LinkStatus myStatus;
+    private final String myTarget;
 
     public ResolvedLink(LinkType linkType, CharSequence url) {
         this(linkType, url, null, LinkStatus.UNKNOWN);
@@ -15,26 +16,36 @@ public class ResolvedLink {
     }
 
     public ResolvedLink(LinkType linkType, CharSequence url, CharSequence title, LinkStatus status) {
+        this(linkType, url, title, status, null);
+    }
+
+    public ResolvedLink(LinkType linkType, CharSequence url, CharSequence title, LinkStatus status, String target) {
         myLinkType = linkType;
         myUrl = url instanceof String ? (String) url : String.valueOf(url);
         myTitle = title == null ? null : title instanceof String ? (String) title : String.valueOf(title);
         myStatus = status;
+        myTarget = target;
     }
-
+    
     // @formatter:off
-    public ResolvedLink withLinkType(LinkType linkType) { return linkType == this.myLinkType ? this : new ResolvedLink(linkType, myUrl, myTitle, myStatus); }
-    public ResolvedLink withStatus(LinkStatus status) { return status == this.myStatus ? this : new ResolvedLink(myLinkType, myUrl, myTitle, status); }
+    public ResolvedLink withLinkType(LinkType linkType) { return linkType == this.myLinkType ? this : new ResolvedLink(linkType, myUrl, myTitle, myStatus, myTarget); }
+    public ResolvedLink withStatus(LinkStatus status) { return status == this.myStatus ? this : new ResolvedLink(myLinkType, myUrl, myTitle, status, myTarget); }
     // @formatter:on
     public ResolvedLink withUrl(CharSequence url) {
         String useUrl = url instanceof String ? (String) url : String.valueOf(url);
-        return this.myUrl.equals(useUrl) ? this : new ResolvedLink(myLinkType, useUrl, myTitle, myStatus);
+        return this.myUrl.equals(useUrl) ? this : new ResolvedLink(myLinkType, useUrl, myTitle, myStatus, myTarget);
     }
 
     public ResolvedLink withTitle(CharSequence title) {
         String useTitle = title == null ? null : title instanceof String ? (String) title : String.valueOf(title);
-        return this.myTitle == useTitle || this.myTitle != null && this.myTitle.equals(useTitle) ? this : new ResolvedLink(myLinkType, myUrl, useTitle, myStatus);
+        return this.myTitle == useTitle || this.myTitle != null && this.myTitle.equals(useTitle) ? this : new ResolvedLink(myLinkType, myUrl, useTitle, myStatus, myTarget);
     }
 
+    public ResolvedLink withTarget(CharSequence target) {
+        String useTarget = target == null ? null : target instanceof String ? (String) target : String.valueOf(target);
+        return this.myTarget == useTarget || this.myTarget != null && this.myTarget.equals(useTarget) ? this : new ResolvedLink(myLinkType, myUrl, myTitle, myStatus, useTarget);
+    }
+    
     public LinkType getLinkType() {
         return myLinkType;
     }
@@ -51,6 +62,10 @@ public class ResolvedLink {
         return myStatus;
     }
 
+    public String getTarget() {
+        return myTarget;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -60,6 +75,7 @@ public class ResolvedLink {
 
         if (!myLinkType.equals(link.myLinkType)) return false;
         if (!myUrl.equals(link.myUrl)) return false;
+        if (!myTarget.equals(link.myTarget)) return false;
         return myStatus.equals(link.myStatus);
     }
 
@@ -68,6 +84,7 @@ public class ResolvedLink {
         int result = myLinkType.hashCode();
         result = 31 * result + myUrl.hashCode();
         result = 31 * result + myStatus.hashCode();
+        result = 31 * result + myTarget.hashCode();
         return result;
     }
 }


### PR DESCRIPTION
I have moved from pegdown to flexmark and all went well. The only bit of functionality I was missing was that I had a custom link renderer that allowed me to set the target attribute on certain links. The attached pull request adds this.

(Apologies for the changes to the whitespace - that was unintentional, and the changes to the pom can be ignored - they were simply there to change the version so I could build).