### PR TITLE
Fix root node replace in post processor

### DIFF
--- a/flexmark-util/src/main/java/com/vladsch/flexmark/util/collection/NodeClassifierVisitor.java
+++ b/flexmark-util/src/main/java/com/vladsch/flexmark/util/collection/NodeClassifierVisitor.java
@@ -58,13 +58,15 @@ public class NodeClassifierVisitor extends NodeVisitorBase implements NodeTracke
                 throw new IllegalStateException("Node must be inserted into the document before calling node tracker nodeAdded functions");
             }
 
-            int parentIndex = myClassifyingNodeTracker.getItems().indexOf(node.getParent());
-            if (parentIndex == -1) {
-                throw new IllegalStateException("Parent node: " + node.getParent() + " of " + node + " is not tracked, some post processor forgot to call tracker.nodeAdded().");
+            if (!(node.getParent() instanceof Document)) {
+                int parentIndex = myClassifyingNodeTracker.getItems().indexOf(node.getParent());
+                if (parentIndex == -1) {
+                    throw new IllegalStateException("Parent node: " + node.getParent() + " of " + node + " is not tracked, some post processor forgot to call tracker.nodeAdded().");
+                }
+    
+                BitSet ancestorBitSet = myNodeAncestryMap.get(parentIndex);
+                myNodeAncestryBitSet.setValue(ancestorBitSet);
             }
-
-            BitSet ancestorBitSet = myNodeAncestryMap.get(parentIndex);
-            myNodeAncestryBitSet.setValue(ancestorBitSet);
 
             // let'er rip to update the descendants
             myNodeAncestryBitSetStack.clear();


### PR DESCRIPTION
When trying to replace a root node in a post processor, an `IllegalStateException` is thrown.
The given node parent (which is the document for a root node) is not in the `myClassifyingNodeTracker`.

I'm not sure about the consequences of this change, so comments are welcome!