### PR TITLE
Bugfix: Missing or wrong package declarations in package-info.java.

### DIFF
--- a/flexmark-ext-gfm-issues/src/main/java/com/vladsch/flexmark/ext/gfm/issues/internal/package-info.java
+++ b/flexmark-ext-gfm-issues/src/main/java/com/vladsch/flexmark/ext/gfm/issues/internal/package-info.java
@@ -1,1 +1,1 @@
-package com.vladsch.flexmark.ext.gfm.issues.Internal;
+package com.vladsch.flexmark.ext.gfm.issues.internal;

--- a/flexmark-ext-ins/src/main/java/com/vladsch/flexmark/ext/ins/package-info.java
+++ b/flexmark-ext-ins/src/main/java/com/vladsch/flexmark/ext/ins/package-info.java
@@ -1,1 +1,1 @@
-
+package com.vladsch.flexmark.ext.ins;


### PR DESCRIPTION
When importing the project into Eclipse, it instantly complains about "compile" errors in `package-info.java` files.