### PR TITLE
Allow customization of wiki link escape.

### DIFF
--- a/flexmark-ext-wikilink/src/main/java/com/vladsch/flexmark/ext/wikilink/WikiLinkExtension.java
+++ b/flexmark-ext-wikilink/src/main/java/com/vladsch/flexmark/ext/wikilink/WikiLinkExtension.java
@@ -34,6 +34,25 @@ public class WikiLinkExtension implements Parser.ParserExtension, HtmlRenderer.H
     public static final DataKey<Boolean> IMAGE_LINKS = new DataKey<Boolean>("IMAGE_LINKS", false);
     public static final DataKey<String> LINK_FILE_EXTENSION = new DataKey<String>("LINK_FILE_EXTENSION", "");
     public static final DataKey<String> IMAGE_FILE_EXTENSION = new DataKey<String>("IMAGE_FILE_EXTENSION", "");
+
+    /**
+	 * Characters to escape in wiki links.
+	 * 
+	 * <p>
+	 * Each character in the configuration string is replaced with a character
+	 * at the corresponding index in the string given by the configuration
+	 * option {@link #LINK_REPLACE_CHARS}.
+	 * </p>
+	 */
+    public static final DataKey<String> LINK_ESCAPE_CHARS = new DataKey<String>("LINK_ESCAPE_CHARS", " +/<>");
+    
+    /**
+     * Characters to replace {@link #LINK_ESCAPE_CHARS} with.
+     * 
+     * @see #LINK_ESCAPE_CHARS
+     */
+    public static final DataKey<String> LINK_REPLACE_CHARS = new DataKey<String>("LINK_REPLACE_CHARS", "-----");
+
     public static final LinkType WIKI_LINK = new LinkType("WIKI");
 
     private WikiLinkExtension() {

--- a/flexmark-ext-wikilink/src/main/java/com/vladsch/flexmark/ext/wikilink/internal/WikiLinkLinkResolver.java
+++ b/flexmark-ext-wikilink/src/main/java/com/vladsch/flexmark/ext/wikilink/internal/WikiLinkLinkResolver.java
@@ -11,8 +11,6 @@ import java.util.Set;
 import static com.vladsch.flexmark.ext.wikilink.WikiLinkExtension.WIKI_LINK;
 
 public class WikiLinkLinkResolver implements LinkResolver {
-    private static String fromChars = " +/<>";
-    private static String toChars = "-----";
     private final WikiLinkOptions options;
 
     public WikiLinkLinkResolver(LinkResolverContext context) {
@@ -30,6 +28,8 @@ public class WikiLinkLinkResolver implements LinkResolver {
 
             boolean hadAnchorRef = false;
 
+            String linkEscapeChars = options.linkEscapeChars;
+            String linkReplaceChars = options.linkReplaceChars;
             for (int i = 0; i < iMax; i++) {
                 char c = wikiLink.charAt(i);
 
@@ -39,12 +39,12 @@ public class WikiLinkLinkResolver implements LinkResolver {
                     hadAnchorRef = true;
                 }
 
-                int pos = fromChars.indexOf(c);
+				int pos = linkEscapeChars.indexOf(c);
 
                 if (pos < 0) {
                     sb.append(c);
                 } else {
-                    sb.append(toChars.charAt(pos));
+					sb.append(linkReplaceChars.charAt(pos));
                 }
             }
 

--- a/flexmark-ext-wikilink/src/main/java/com/vladsch/flexmark/ext/wikilink/internal/WikiLinkOptions.java
+++ b/flexmark-ext-wikilink/src/main/java/com/vladsch/flexmark/ext/wikilink/internal/WikiLinkOptions.java
@@ -15,6 +15,8 @@ public class WikiLinkOptions {
     public final String imagePrefix;
     public final String linkFileExtension;
     public final String linkPrefix;
+	public final String linkReplaceChars;
+	public final String linkEscapeChars;
 
     public WikiLinkOptions(DataHolder options) {
         this.allowInlines = WikiLinkExtension.ALLOW_INLINES.getFrom(options);
@@ -28,5 +30,7 @@ public class WikiLinkOptions {
         this.imagePrefix = WikiLinkExtension.IMAGE_PREFIX.getFrom(options);
         this.linkFileExtension = WikiLinkExtension.LINK_FILE_EXTENSION.getFrom(options);
         this.linkPrefix = WikiLinkExtension.LINK_PREFIX.getFrom(options);
+        this.linkEscapeChars = WikiLinkExtension.LINK_ESCAPE_CHARS.getFrom(options);
+        this.linkReplaceChars = WikiLinkExtension.LINK_REPLACE_CHARS.getFrom(options);
     }
 }

--- a/flexmark-ext-wikilink/src/test/java/com/vladsch/flexmark/ext/wikilink/ComboWikiLinkSpecTest.java
+++ b/flexmark-ext-wikilink/src/test/java/com/vladsch/flexmark/ext/wikilink/ComboWikiLinkSpecTest.java
@@ -32,6 +32,7 @@ public class ComboWikiLinkSpecTest extends ComboSpecTestCase {
         optionsMap.put("allow-anchors", new MutableDataSet().set(WikiLinkExtension.ALLOW_ANCHORS, true));
         optionsMap.put("allow-pipe-escape", new MutableDataSet().set(WikiLinkExtension.ALLOW_PIPE_ESCAPE, true));
         optionsMap.put("allow-anchor-escape", new MutableDataSet().set(WikiLinkExtension.ALLOW_ANCHOR_ESCAPE, true));
+        optionsMap.put("custom-link-escape", new MutableDataSet().set(WikiLinkExtension.LINK_ESCAPE_CHARS, " +<>").set(WikiLinkExtension.LINK_REPLACE_CHARS, "____"));
     }
 
     static final Parser PARSER = Parser.builder(OPTIONS).build();

--- a/flexmark-ext-wikilink/src/test/resources/ext_wikilink_ast_spec.md
+++ b/flexmark-ext-wikilink/src/test/resources/ext_wikilink_ast_spec.md
@@ -1162,6 +1162,42 @@ Document[0, 24]
 ````````````````````````````````
 
 
+Custom link escape
+
+With configuration options `LINK_ESCAPE_CHARS` and `LINK_REPLACE_CHARS` it is possible to change the link escaping. `LINK_ESCAPE_CHARS` gives the character to escape in links. `LINK_REPLACE_CHARS` gives the correponding replacement characters.
+
+```````````````````````````````` example(WikiLinks: 60) options(custom-link-escape)
+See [[My Page]].
+.
+<p>See <a href="My_Page">My Page</a>.</p>
+.
+Document[0, 16]
+  Paragraph[0, 16]
+    Text[0, 4] chars:[0, 4, "See "]
+    WikiLink[4, 15] linkOpen:[4, 6, "[["] link:[6, 13, "My Page"] pageRef:[6, 13, "My Page"] linkClose:[13, 15, "]]"]
+      Text[6, 13] chars:[6, 13, "My Page"]
+    Text[15, 16] chars:[15, 16, "."]
+````````````````````````````````
+
+
+Links to virtual directories
+
+With configuration options `LINK_ESCAPE_CHARS` and `LINK_REPLACE_CHARS` it is possible to create wiki links to virtual directories (links containing the `/` character.
+
+```````````````````````````````` example(WikiLinks: 61) options(custom-link-escape)
+See [[directory/WikiPage]].
+.
+<p>See <a href="directory/WikiPage">directory/WikiPage</a>.</p>
+.
+Document[0, 27]
+  Paragraph[0, 27]
+    Text[0, 4] chars:[0, 4, "See "]
+    WikiLink[4, 26] linkOpen:[4, 6, "[["] link:[6, 24, "directory/WikiPage"] pageRef:[6, 24, "directory/WikiPage"] linkClose:[24, 26, "]]"]
+      Text[6, 24] chars:[6, 24, "direc … iPage"]
+    Text[26, 27] chars:[26, 27, "."]
+````````````````````````````````
+
+
 ## Wiki Typographic Text
 
 With empty anchor ref


### PR DESCRIPTION
Escaping of wiki links is hard-coded. Especially the `/` character is replaced with `-`. This effectively prevents to create wikis with virtual directories. There should be at least an option to change the link escaping behavior by specifying the characters to replace and their replacements.

Two new configuration options are introduced. `LINK_ESCAPE_CHARS` gives the link characters to escape and `LINK_REPLACE_CHARS` give the corresponding replacement characters. This allows disabling the escaping of the `/` character enabling wiki links like `[[virtual-dir/my-page]]`.