### PR TITLE
Introduce a maven property for version number.

### DIFF
--- a/flexmark-all/pom.xml
+++ b/flexmark-all/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.vladsch.flexmark</groupId>
         <artifactId>flexmark-java</artifactId>
-        <version>0.28.24</version>
+        <version>${flexmark.version}</version>
     </parent>
 
     <artifactId>flexmark-all</artifactId>
@@ -21,172 +21,138 @@
         <dependency>
             <groupId>com.vladsch.flexmark</groupId>
             <artifactId>flexmark</artifactId>
-            <version>0.28.24</version>
         </dependency>
         <dependency>
             <groupId>com.vladsch.flexmark</groupId>
             <artifactId>flexmark-ext-abbreviation</artifactId>
-            <version>0.28.24</version>
         </dependency>
         <dependency>
             <groupId>com.vladsch.flexmark</groupId>
             <artifactId>flexmark-ext-anchorlink</artifactId>
-            <version>0.28.24</version>
         </dependency>
         <dependency>
             <groupId>com.vladsch.flexmark</groupId>
             <artifactId>flexmark-ext-aside</artifactId>
-            <version>0.28.24</version>
         </dependency>
         <dependency>
             <groupId>com.vladsch.flexmark</groupId>
             <artifactId>flexmark-ext-attributes</artifactId>
-            <version>0.28.24</version>
         </dependency>
         <dependency>
             <groupId>com.vladsch.flexmark</groupId>
             <artifactId>flexmark-ext-autolink</artifactId>
-            <version>0.28.24</version>
         </dependency>
         <dependency>
             <groupId>com.vladsch.flexmark</groupId>
             <artifactId>flexmark-ext-definition</artifactId>
-            <version>0.28.24</version>
         </dependency>
         <dependency>
             <groupId>com.vladsch.flexmark</groupId>
             <artifactId>flexmark-ext-emoji</artifactId>
-            <version>0.28.24</version>
         </dependency>
         <dependency>
             <groupId>com.vladsch.flexmark</groupId>
             <artifactId>flexmark-ext-enumerated-reference</artifactId>
-            <version>0.28.24</version>
         </dependency>
         <dependency>
             <groupId>com.vladsch.flexmark</groupId>
             <artifactId>flexmark-ext-escaped-character</artifactId>
-            <version>0.28.24</version>
         </dependency>
         <dependency>
             <groupId>com.vladsch.flexmark</groupId>
             <artifactId>flexmark-ext-footnotes</artifactId>
-            <version>0.28.24</version>
         </dependency>
         <dependency>
             <groupId>com.vladsch.flexmark</groupId>
             <artifactId>flexmark-ext-gfm-issues</artifactId>
-            <version>0.28.24</version>
         </dependency>
         <dependency>
             <groupId>com.vladsch.flexmark</groupId>
             <artifactId>flexmark-ext-gfm-strikethrough</artifactId>
-            <version>0.28.24</version>
         </dependency>
         <dependency>
             <groupId>com.vladsch.flexmark</groupId>
             <artifactId>flexmark-ext-gfm-tables</artifactId>
-            <version>0.28.24</version>
         </dependency>
         <dependency>
             <groupId>com.vladsch.flexmark</groupId>
             <artifactId>flexmark-ext-gfm-tasklist</artifactId>
-            <version>0.28.24</version>
         </dependency>
         <dependency>
             <groupId>com.vladsch.flexmark</groupId>
             <artifactId>flexmark-ext-gfm-users</artifactId>
-            <version>0.28.24</version>
         </dependency>
         <dependency>
             <groupId>com.vladsch.flexmark</groupId>
             <artifactId>flexmark-ext-jekyll-front-matter</artifactId>
-            <version>0.28.24</version>
         </dependency>
         <dependency>
             <groupId>com.vladsch.flexmark</groupId>
             <artifactId>flexmark-ext-jekyll-tag</artifactId>
-            <version>0.28.24</version>
         </dependency>
         <dependency>
             <groupId>com.vladsch.flexmark</groupId>
             <artifactId>flexmark-ext-ins</artifactId>
-            <version>0.28.24</version>
         </dependency>
         <dependency>
             <groupId>com.vladsch.flexmark</groupId>
             <artifactId>flexmark-ext-xwiki-macros</artifactId>
-            <version>0.28.24</version>
         </dependency>
         <dependency>
             <groupId>com.vladsch.flexmark</groupId>
             <artifactId>flexmark-ext-superscript</artifactId>
-            <version>0.28.24</version>
         </dependency>
         <dependency>
             <groupId>com.vladsch.flexmark</groupId>
             <artifactId>flexmark-ext-tables</artifactId>
-            <version>0.28.24</version>
         </dependency>
         <dependency>
             <groupId>com.vladsch.flexmark</groupId>
             <artifactId>flexmark-ext-toc</artifactId>
-            <version>0.28.24</version>
         </dependency>
         <dependency>
             <groupId>com.vladsch.flexmark</groupId>
             <artifactId>flexmark-ext-typographic</artifactId>
-            <version>0.28.24</version>
         </dependency>
         <dependency>
             <groupId>com.vladsch.flexmark</groupId>
             <artifactId>flexmark-ext-wikilink</artifactId>
-            <version>0.28.24</version>
         </dependency>
         <dependency>
             <groupId>com.vladsch.flexmark</groupId>
             <artifactId>flexmark-ext-yaml-front-matter</artifactId>
-            <version>0.28.24</version>
         </dependency>
         <dependency>
             <groupId>com.vladsch.flexmark</groupId>
             <artifactId>flexmark-ext-youtube-embedded</artifactId>
-            <version>0.28.24</version>
         </dependency>
         <dependency>
             <groupId>com.vladsch.flexmark</groupId>
             <artifactId>flexmark-formatter</artifactId>
-            <version>0.28.24</version>
         </dependency>
         <dependency>
             <groupId>com.vladsch.flexmark</groupId>
             <artifactId>flexmark-html-parser</artifactId>
-            <version>0.28.24</version>
         </dependency>
         <dependency>
             <groupId>com.vladsch.flexmark</groupId>
             <artifactId>flexmark-jira-converter</artifactId>
-            <version>0.28.24</version>
         </dependency>
         <dependency>
             <groupId>com.vladsch.flexmark</groupId>
             <artifactId>flexmark-pdf-converter</artifactId>
-            <version>0.28.24</version>
         </dependency>
         <dependency>
             <groupId>com.vladsch.flexmark</groupId>
             <artifactId>flexmark-profile-pegdown</artifactId>
-            <version>0.28.24</version>
         </dependency>
         <dependency>
             <groupId>com.vladsch.flexmark</groupId>
             <artifactId>flexmark-util</artifactId>
-            <version>0.28.24</version>
         </dependency>
         <dependency>
             <groupId>com.vladsch.flexmark</groupId>
             <artifactId>flexmark-youtrack-converter</artifactId>
-            <version>0.28.24</version>
         </dependency>
     </dependencies>
 

--- a/flexmark-docx-converter/pom.xml
+++ b/flexmark-docx-converter/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vladsch.flexmark</groupId>
         <artifactId>flexmark-java</artifactId>
-        <version>0.28.24</version>
+        <version>${flexmark.version}</version>
     </parent>
 
     <artifactId>flexmark-docx-converter</artifactId>

--- a/flexmark-ext-abbreviation/pom.xml
+++ b/flexmark-ext-abbreviation/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vladsch.flexmark</groupId>
         <artifactId>flexmark-java</artifactId>
-        <version>0.28.24</version>
+        <version>${flexmark.version}</version>
     </parent>
 
     <artifactId>flexmark-ext-abbreviation</artifactId>

--- a/flexmark-ext-anchorlink/pom.xml
+++ b/flexmark-ext-anchorlink/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vladsch.flexmark</groupId>
         <artifactId>flexmark-java</artifactId>
-        <version>0.28.24</version>
+        <version>${flexmark.version}</version>
     </parent>
 
     <artifactId>flexmark-ext-anchorlink</artifactId>
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>com.vladsch.flexmark</groupId>
             <artifactId>flexmark-jira-converter</artifactId>
-            <version>0.28.24</version>
+            <version>${flexmark.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/flexmark-ext-aside/pom.xml
+++ b/flexmark-ext-aside/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vladsch.flexmark</groupId>
         <artifactId>flexmark-java</artifactId>
-        <version>0.28.24</version>
+        <version>${flexmark.version}</version>
     </parent>
 
     <artifactId>flexmark-ext-aside</artifactId>

--- a/flexmark-ext-attributes/pom.xml
+++ b/flexmark-ext-attributes/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vladsch.flexmark</groupId>
         <artifactId>flexmark-java</artifactId>
-        <version>0.28.24</version>
+        <version>${flexmark.version}</version>
     </parent>
 
     <artifactId>flexmark-ext-attributes</artifactId>

--- a/flexmark-ext-autolink/pom.xml
+++ b/flexmark-ext-autolink/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vladsch.flexmark</groupId>
         <artifactId>flexmark-java</artifactId>
-        <version>0.28.24</version>
+        <version>${flexmark.version}</version>
     </parent>
 
     <artifactId>flexmark-ext-autolink</artifactId>

--- a/flexmark-ext-definition/pom.xml
+++ b/flexmark-ext-definition/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vladsch.flexmark</groupId>
         <artifactId>flexmark-java</artifactId>
-        <version>0.28.24</version>
+        <version>${flexmark.version}</version>
     </parent>
 
     <artifactId>flexmark-ext-definition</artifactId>

--- a/flexmark-ext-emoji/pom.xml
+++ b/flexmark-ext-emoji/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vladsch.flexmark</groupId>
         <artifactId>flexmark-java</artifactId>
-        <version>0.28.24</version>
+        <version>${flexmark.version}</version>
     </parent>
 
     <artifactId>flexmark-ext-emoji</artifactId>

--- a/flexmark-ext-enumerated-reference/pom.xml
+++ b/flexmark-ext-enumerated-reference/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vladsch.flexmark</groupId>
         <artifactId>flexmark-java</artifactId>
-        <version>0.28.24</version>
+        <version>${flexmark.version}</version>
     </parent>
 
     <artifactId>flexmark-ext-enumerated-reference</artifactId>

--- a/flexmark-ext-escaped-character/pom.xml
+++ b/flexmark-ext-escaped-character/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vladsch.flexmark</groupId>
         <artifactId>flexmark-java</artifactId>
-        <version>0.28.24</version>
+        <version>${flexmark.version}</version>
     </parent>
 
     <artifactId>flexmark-ext-escaped-character</artifactId>

--- a/flexmark-ext-footnotes/pom.xml
+++ b/flexmark-ext-footnotes/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vladsch.flexmark</groupId>
         <artifactId>flexmark-java</artifactId>
-        <version>0.28.24</version>
+        <version>${flexmark.version}</version>
     </parent>
 
     <artifactId>flexmark-ext-footnotes</artifactId>

--- a/flexmark-ext-gfm-issues/pom.xml
+++ b/flexmark-ext-gfm-issues/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vladsch.flexmark</groupId>
         <artifactId>flexmark-java</artifactId>
-        <version>0.28.24</version>
+        <version>${flexmark.version}</version>
     </parent>
 
     <artifactId>flexmark-ext-gfm-issues</artifactId>

--- a/flexmark-ext-gfm-strikethrough/pom.xml
+++ b/flexmark-ext-gfm-strikethrough/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vladsch.flexmark</groupId>
         <artifactId>flexmark-java</artifactId>
-        <version>0.28.24</version>
+        <version>${flexmark.version}</version>
     </parent>
 
     <artifactId>flexmark-ext-gfm-strikethrough</artifactId>

--- a/flexmark-ext-gfm-tables/pom.xml
+++ b/flexmark-ext-gfm-tables/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vladsch.flexmark</groupId>
         <artifactId>flexmark-java</artifactId>
-        <version>0.28.24</version>
+        <version>${flexmark.version}</version>
     </parent>
 
     <artifactId>flexmark-ext-gfm-tables</artifactId>

--- a/flexmark-ext-gfm-tasklist/pom.xml
+++ b/flexmark-ext-gfm-tasklist/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vladsch.flexmark</groupId>
         <artifactId>flexmark-java</artifactId>
-        <version>0.28.24</version>
+        <version>${flexmark.version}</version>
     </parent>
 
     <artifactId>flexmark-ext-gfm-tasklist</artifactId>

--- a/flexmark-ext-gfm-users/pom.xml
+++ b/flexmark-ext-gfm-users/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vladsch.flexmark</groupId>
         <artifactId>flexmark-java</artifactId>
-        <version>0.28.24</version>
+        <version>${flexmark.version}</version>
     </parent>
 
     <artifactId>flexmark-ext-gfm-users</artifactId>

--- a/flexmark-ext-ins/pom.xml
+++ b/flexmark-ext-ins/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vladsch.flexmark</groupId>
         <artifactId>flexmark-java</artifactId>
-        <version>0.28.24</version>
+        <version>${flexmark.version}</version>
     </parent>
 
     <artifactId>flexmark-ext-ins</artifactId>

--- a/flexmark-ext-jekyll-front-matter/pom.xml
+++ b/flexmark-ext-jekyll-front-matter/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vladsch.flexmark</groupId>
         <artifactId>flexmark-java</artifactId>
-        <version>0.28.24</version>
+        <version>${flexmark.version}</version>
     </parent>
 
     <artifactId>flexmark-ext-jekyll-front-matter</artifactId>

--- a/flexmark-ext-jekyll-tag/pom.xml
+++ b/flexmark-ext-jekyll-tag/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vladsch.flexmark</groupId>
         <artifactId>flexmark-java</artifactId>
-        <version>0.28.24</version>
+        <version>${flexmark.version}</version>
     </parent>
 
     <artifactId>flexmark-ext-jekyll-tag</artifactId>

--- a/flexmark-ext-spec-example/pom.xml
+++ b/flexmark-ext-spec-example/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vladsch.flexmark</groupId>
         <artifactId>flexmark-java</artifactId>
-        <version>0.28.24</version>
+        <version>${flexmark.version}</version>
     </parent>
 
     <artifactId>flexmark-ext-spec-example</artifactId>

--- a/flexmark-ext-superscript/pom.xml
+++ b/flexmark-ext-superscript/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vladsch.flexmark</groupId>
         <artifactId>flexmark-java</artifactId>
-        <version>0.28.24</version>
+        <version>${flexmark.version}</version>
     </parent>
 
     <artifactId>flexmark-ext-superscript</artifactId>

--- a/flexmark-ext-tables/pom.xml
+++ b/flexmark-ext-tables/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vladsch.flexmark</groupId>
         <artifactId>flexmark-java</artifactId>
-        <version>0.28.24</version>
+        <version>${flexmark.version}</version>
     </parent>
 
     <artifactId>flexmark-ext-tables</artifactId>

--- a/flexmark-ext-toc/pom.xml
+++ b/flexmark-ext-toc/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vladsch.flexmark</groupId>
         <artifactId>flexmark-java</artifactId>
-        <version>0.28.24</version>
+        <version>${flexmark.version}</version>
     </parent>
 
     <artifactId>flexmark-ext-toc</artifactId>

--- a/flexmark-ext-typographic/pom.xml
+++ b/flexmark-ext-typographic/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vladsch.flexmark</groupId>
         <artifactId>flexmark-java</artifactId>
-        <version>0.28.24</version>
+        <version>${flexmark.version}</version>
     </parent>
 
     <artifactId>flexmark-ext-typographic</artifactId>

--- a/flexmark-ext-wikilink/pom.xml
+++ b/flexmark-ext-wikilink/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vladsch.flexmark</groupId>
         <artifactId>flexmark-java</artifactId>
-        <version>0.28.24</version>
+        <version>${flexmark.version}</version>
     </parent>
 
     <artifactId>flexmark-ext-wikilink</artifactId>

--- a/flexmark-ext-xwiki-macros/pom.xml
+++ b/flexmark-ext-xwiki-macros/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vladsch.flexmark</groupId>
         <artifactId>flexmark-java</artifactId>
-        <version>0.28.24</version>
+        <version>${flexmark.version}</version>
     </parent>
 
     <artifactId>flexmark-ext-xwiki-macros</artifactId>

--- a/flexmark-ext-yaml-front-matter/pom.xml
+++ b/flexmark-ext-yaml-front-matter/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>flexmark-java</artifactId>
         <groupId>com.vladsch.flexmark</groupId>
-        <version>0.28.24</version>
+        <version>${flexmark.version}</version>
     </parent>
 
     <artifactId>flexmark-ext-yaml-front-matter</artifactId>

--- a/flexmark-ext-youtube-embedded/pom.xml
+++ b/flexmark-ext-youtube-embedded/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>flexmark-java</artifactId>
         <groupId>com.vladsch.flexmark</groupId>
-        <version>0.28.24</version>
+        <version>${flexmark.version}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flexmark-ext-zzzzzz/pom.xml
+++ b/flexmark-ext-zzzzzz/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vladsch.flexmark</groupId>
         <artifactId>flexmark-java</artifactId>
-        <version>0.28.24</version>
+        <version>${flexmark.version}</version>
     </parent>
 
     <artifactId>flexmark-ext-zzzzzz</artifactId>

--- a/flexmark-formatter/pom.xml
+++ b/flexmark-formatter/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vladsch.flexmark</groupId>
         <artifactId>flexmark-java</artifactId>
-        <version>0.28.24</version>
+        <version>${flexmark.version}</version>
     </parent>
 
     <artifactId>flexmark-formatter</artifactId>

--- a/flexmark-html-parser/pom.xml
+++ b/flexmark-html-parser/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vladsch.flexmark</groupId>
         <artifactId>flexmark-java</artifactId>
-        <version>0.28.24</version>
+        <version>${flexmark.version}</version>
     </parent>
 
     <artifactId>flexmark-html-parser</artifactId>

--- a/flexmark-integration-test/pom.xml
+++ b/flexmark-integration-test/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vladsch.flexmark</groupId>
         <artifactId>flexmark-java</artifactId>
-        <version>0.28.24</version>
+        <version>${flexmark.version}</version>
     </parent>
 
     <artifactId>flexmark-integration-test</artifactId>

--- a/flexmark-jira-converter/pom.xml
+++ b/flexmark-jira-converter/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vladsch.flexmark</groupId>
         <artifactId>flexmark-java</artifactId>
-        <version>0.28.24</version>
+        <version>${flexmark.version}</version>
     </parent>
 
     <artifactId>flexmark-jira-converter</artifactId>

--- a/flexmark-pdf-converter/pom.xml
+++ b/flexmark-pdf-converter/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vladsch.flexmark</groupId>
         <artifactId>flexmark-java</artifactId>
-        <version>0.28.24</version>
+        <version>${flexmark.version}</version>
     </parent>
 
     <artifactId>flexmark-pdf-converter</artifactId>

--- a/flexmark-profile-pegdown/pom.xml
+++ b/flexmark-profile-pegdown/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vladsch.flexmark</groupId>
         <artifactId>flexmark-java</artifactId>
-        <version>0.28.24</version>
+        <version>${flexmark.version}</version>
     </parent>
 
     <artifactId>flexmark-profile-pegdown</artifactId>

--- a/flexmark-test-util/pom.xml
+++ b/flexmark-test-util/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vladsch.flexmark</groupId>
         <artifactId>flexmark-java</artifactId>
-        <version>0.28.24</version>
+        <version>${flexmark.version}</version>
     </parent>
 
     <artifactId>flexmark-test-util</artifactId>

--- a/flexmark-util/pom.xml
+++ b/flexmark-util/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vladsch.flexmark</groupId>
         <artifactId>flexmark-java</artifactId>
-        <version>0.28.24</version>
+        <version>${flexmark.version}</version>
     </parent>
 
     <artifactId>flexmark-util</artifactId>

--- a/flexmark-youtrack-converter/pom.xml
+++ b/flexmark-youtrack-converter/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vladsch.flexmark</groupId>
         <artifactId>flexmark-java</artifactId>
-        <version>0.28.24</version>
+        <version>${flexmark.version}</version>
     </parent>
 
     <artifactId>flexmark-youtrack-converter</artifactId>

--- a/flexmark/pom.xml
+++ b/flexmark/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vladsch.flexmark</groupId>
         <artifactId>flexmark-java</artifactId>
-        <version>0.28.24</version>
+        <version>${flexmark.version}</version>
     </parent>
 
     <artifactId>flexmark</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>com.vladsch.flexmark</groupId>
     <artifactId>flexmark-java</artifactId>
-    <version>0.28.24</version>
+    <version>${flexmark.version}</version>
     <name>flexmark-java</name>
     <description>
         Java re-implementation of commonmark-java based parser, with AST reflecting source elements, full source position tracking, greater parser extensibility.
@@ -69,6 +69,7 @@
         <flexmark.javadoc.location>${project.basedir}/target/apidocs/</flexmark.javadoc.location>
         <!-- Don't automatically publish artifacts to Central, we might want to inspect them first. -->
         <nexus.staging.autoRelease>false</nexus.staging.autoRelease>
+        <flexmark.version>0.28.24</flexmark.version>
     </properties>
 
     <distributionManagement>
@@ -216,197 +217,197 @@
             <dependency>
                 <groupId>com.vladsch.flexmark</groupId>
                 <artifactId>flexmark</artifactId>
-                <version>0.28.24</version>
+                <version>${flexmark.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.vladsch.flexmark</groupId>
                 <artifactId>flexmark-docx-converter</artifactId>
-                <version>0.28.24</version>
+                <version>${flexmark.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.vladsch.flexmark</groupId>
                 <artifactId>flexmark-ext-abbreviation</artifactId>
-                <version>0.28.24</version>
+                <version>${flexmark.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.vladsch.flexmark</groupId>
                 <artifactId>flexmark-ext-anchorlink</artifactId>
-                <version>0.28.24</version>
+                <version>${flexmark.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.vladsch.flexmark</groupId>
                 <artifactId>flexmark-ext-aside</artifactId>
-                <version>0.28.24</version>
+                <version>${flexmark.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.vladsch.flexmark</groupId>
                 <artifactId>flexmark-ext-attributes</artifactId>
-                <version>0.28.24</version>
+                <version>${flexmark.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.vladsch.flexmark</groupId>
                 <artifactId>flexmark-ext-autolink</artifactId>
-                <version>0.28.24</version>
+                <version>${flexmark.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.vladsch.flexmark</groupId>
                 <artifactId>flexmark-ext-definition</artifactId>
-                <version>0.28.24</version>
+                <version>${flexmark.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.vladsch.flexmark</groupId>
                 <artifactId>flexmark-ext-emoji</artifactId>
-                <version>0.28.24</version>
+                <version>${flexmark.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.vladsch.flexmark</groupId>
                 <artifactId>flexmark-ext-enumerated-reference</artifactId>
-                <version>0.28.24</version>
+                <version>${flexmark.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.vladsch.flexmark</groupId>
                 <artifactId>flexmark-ext-escaped-character</artifactId>
-                <version>0.28.24</version>
+                <version>${flexmark.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.vladsch.flexmark</groupId>
                 <artifactId>flexmark-ext-footnotes</artifactId>
-                <version>0.28.24</version>
+                <version>${flexmark.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.vladsch.flexmark</groupId>
                 <artifactId>flexmark-ext-gfm-issues</artifactId>
-                <version>0.28.24</version>
+                <version>${flexmark.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.vladsch.flexmark</groupId>
                 <artifactId>flexmark-ext-gfm-strikethrough</artifactId>
-                <version>0.28.24</version>
+                <version>${flexmark.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.vladsch.flexmark</groupId>
                 <artifactId>flexmark-ext-gfm-tables</artifactId>
-                <version>0.28.24</version>
+                <version>${flexmark.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.vladsch.flexmark</groupId>
                 <artifactId>flexmark-ext-gfm-tasklist</artifactId>
-                <version>0.28.24</version>
+                <version>${flexmark.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.vladsch.flexmark</groupId>
                 <artifactId>flexmark-ext-gfm-users</artifactId>
-                <version>0.28.24</version>
+                <version>${flexmark.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.vladsch.flexmark</groupId>
                 <artifactId>flexmark-ext-jekyll-front-matter</artifactId>
-                <version>0.28.24</version>
+                <version>${flexmark.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.vladsch.flexmark</groupId>
                 <artifactId>flexmark-ext-jekyll-tag</artifactId>
-                <version>0.28.24</version>
+                <version>${flexmark.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.vladsch.flexmark</groupId>
                 <artifactId>flexmark-ext-ins</artifactId>
-                <version>0.28.24</version>
+                <version>${flexmark.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.vladsch.flexmark</groupId>
                 <artifactId>flexmark-ext-xwiki-macros</artifactId>
-                <version>0.28.24</version>
+                <version>${flexmark.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.vladsch.flexmark</groupId>
                 <artifactId>flexmark-ext-spec-example</artifactId>
-                <version>0.28.24</version>
+                <version>${flexmark.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.vladsch.flexmark</groupId>
                 <artifactId>flexmark-ext-superscript</artifactId>
-                <version>0.28.24</version>
+                <version>${flexmark.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.vladsch.flexmark</groupId>
                 <artifactId>flexmark-ext-tables</artifactId>
-                <version>0.28.24</version>
+                <version>${flexmark.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.vladsch.flexmark</groupId>
                 <artifactId>flexmark-ext-toc</artifactId>
-                <version>0.28.24</version>
+                <version>${flexmark.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.vladsch.flexmark</groupId>
                 <artifactId>flexmark-ext-typographic</artifactId>
-                <version>0.28.24</version>
+                <version>${flexmark.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.vladsch.flexmark</groupId>
                 <artifactId>flexmark-ext-wikilink</artifactId>
-                <version>0.28.24</version>
+                <version>${flexmark.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.vladsch.flexmark</groupId>
                 <artifactId>flexmark-ext-yaml-front-matter</artifactId>
-                <version>0.28.24</version>
+                <version>${flexmark.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.vladsch.flexmark</groupId>
                 <artifactId>flexmark-ext-youtube-embedded</artifactId>
-                <version>0.28.24</version>
+                <version>${flexmark.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.vladsch.flexmark</groupId>
                 <artifactId>flexmark-ext-zzzzzz</artifactId>
-                <version>0.28.24</version>
+                <version>${flexmark.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.vladsch.flexmark</groupId>
                 <artifactId>flexmark-formatter</artifactId>
-                <version>0.28.24</version>
+                <version>${flexmark.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.vladsch.flexmark</groupId>
                 <artifactId>flexmark-html-parser</artifactId>
-                <version>0.28.24</version>
+                <version>${flexmark.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.vladsch.flexmark</groupId>
                 <artifactId>flexmark-jira-converter</artifactId>
-                <version>0.28.24</version>
+                <version>${flexmark.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.vladsch.flexmark</groupId>
                 <artifactId>flexmark-pdf-converter</artifactId>
-                <version>0.28.24</version>
+                <version>${flexmark.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.vladsch.flexmark</groupId>
                 <artifactId>flexmark-profile-pegdown</artifactId>
-                <version>0.28.24</version>
+                <version>${flexmark.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.vladsch.flexmark</groupId>
                 <artifactId>flexmark-test-util</artifactId>
-                <version>0.28.24</version>
+                <version>${flexmark.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.vladsch.flexmark</groupId>
                 <artifactId>flexmark-util</artifactId>
-                <version>0.28.24</version>
+                <version>${flexmark.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.vladsch.flexmark</groupId>
                 <artifactId>flexmark-youtrack-converter</artifactId>
-                <version>0.28.24</version>
+                <version>${flexmark.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.vladsch.flexmark</groupId>
                 <artifactId>flexmark-all</artifactId>
-                <version>0.28.24</version>
+                <version>${flexmark.version}</version>
             </dependency>
 
             <!-- Common test dependencies -->


### PR DESCRIPTION
For local developer builds, it is convenient to allow assigning the target version through a command-line argument: 

```
mvn -Dflexmark.version=0.28.25-SNAPSHOT clean compile
```

To achieve this, a maven property is required for the target flexmark version number. This even makes new releases easier, since not all `pom.xml` of all modules have to be touched for creating a new version. 