### PR TITLE
Bugfix: Platform-dependent encoding for test fixture.

### DIFF
--- a/flexmark/src/test/java/com/vladsch/flexmark/test/ParserTest.java
+++ b/flexmark/src/test/java/com/vladsch/flexmark/test/ParserTest.java
@@ -37,7 +37,7 @@ public class ParserTest {
 
         InputStream input1 = SpecReader.getSpecInputStream();
         Node document1;
-        InputStreamReader reader = new InputStreamReader(input1);
+        InputStreamReader reader = new InputStreamReader(input1, "utf-8");
         document1 = parser.parseReader(reader);
 
         String spec = SpecReader.readSpec();


### PR DESCRIPTION
On Windows, the build fails, when trying to execute from the command line. The problem is that `ParserTest` uses a platform-dependent API for reading a test fixture (`new InputStreamReader(input)`). This API uses a platform-dependent encoding for interpreting the read bytes. 