### PR TITLE
Support absolute wiki links

### DIFF
--- a/flexmark-ext-wikilink/src/main/java/com/vladsch/flexmark/ext/wikilink/WikiLinkExtension.java
+++ b/flexmark-ext-wikilink/src/main/java/com/vladsch/flexmark/ext/wikilink/WikiLinkExtension.java
@@ -30,7 +30,27 @@ public class WikiLinkExtension implements Parser.ParserExtension, HtmlRenderer.H
     public static final DataKey<Boolean> DISABLE_RENDERING = new DataKey<Boolean>("DISABLE_RENDERING", false);
     public static final DataKey<Boolean> LINK_FIRST_SYNTAX = new DataKey<Boolean>("LINK_FIRST_SYNTAX", false);
     public static final DataKey<String> LINK_PREFIX = new DataKey<String>("LINK_PREFIX", "");
+    
+    /**
+     * Link prefix to use for absolute wiki links starting with the <code>'/'</code> character.
+     * 
+     * <p>
+     * The default value is value of option {@link #LINK_PREFIX}.
+     * </p>
+     */
+    public static final DataKey<String> LINK_PREFIX_ABSOLUTE = new DataKey<String>("LINK_PREFIX_ABSOLUTE", LINK_PREFIX);
+    
     public static final DataKey<String> IMAGE_PREFIX = new DataKey<String>("IMAGE_PREFIX", "");
+    
+    /**
+     * Image prefix to use for absolute wiki image sources starting with the <code>'/'</code> character.
+     * 
+     * <p>
+     * The default value is value of option {@link #IMAGE_PREFIX}.
+     * </p>
+     */
+    public static final DataKey<String> IMAGE_PREFIX_ABSOLUTE = new DataKey<String>("IMAGE_PREFIX_ABSOLUTE", IMAGE_PREFIX);
+    
     public static final DataKey<Boolean> IMAGE_LINKS = new DataKey<Boolean>("IMAGE_LINKS", false);
     public static final DataKey<String> LINK_FILE_EXTENSION = new DataKey<String>("LINK_FILE_EXTENSION", "");
     public static final DataKey<String> IMAGE_FILE_EXTENSION = new DataKey<String>("IMAGE_FILE_EXTENSION", "");

--- a/flexmark-ext-wikilink/src/main/java/com/vladsch/flexmark/ext/wikilink/internal/WikiLinkLinkResolver.java
+++ b/flexmark-ext-wikilink/src/main/java/com/vladsch/flexmark/ext/wikilink/internal/WikiLinkLinkResolver.java
@@ -1,17 +1,14 @@
 package com.vladsch.flexmark.ext.wikilink.internal;
 
-import static com.vladsch.flexmark.ext.wikilink.WikiLinkExtension.*;
-
-import java.util.Set;
-
 import com.vladsch.flexmark.ast.Node;
 import com.vladsch.flexmark.ext.wikilink.WikiImage;
 import com.vladsch.flexmark.html.LinkResolver;
 import com.vladsch.flexmark.html.LinkResolverFactory;
-import com.vladsch.flexmark.html.renderer.LinkResolverContext;
-import com.vladsch.flexmark.html.renderer.LinkStatus;
-import com.vladsch.flexmark.html.renderer.LinkType;
-import com.vladsch.flexmark.html.renderer.ResolvedLink;
+import com.vladsch.flexmark.html.renderer.*;
+
+import java.util.Set;
+
+import static com.vladsch.flexmark.ext.wikilink.WikiLinkExtension.WIKI_LINK;
 
 public class WikiLinkLinkResolver implements LinkResolver {
     private final WikiLinkOptions options;

--- a/flexmark-ext-wikilink/src/main/java/com/vladsch/flexmark/ext/wikilink/internal/WikiLinkLinkResolver.java
+++ b/flexmark-ext-wikilink/src/main/java/com/vladsch/flexmark/ext/wikilink/internal/WikiLinkLinkResolver.java
@@ -1,14 +1,17 @@
 package com.vladsch.flexmark.ext.wikilink.internal;
 
+import static com.vladsch.flexmark.ext.wikilink.WikiLinkExtension.*;
+
+import java.util.Set;
+
 import com.vladsch.flexmark.ast.Node;
 import com.vladsch.flexmark.ext.wikilink.WikiImage;
 import com.vladsch.flexmark.html.LinkResolver;
 import com.vladsch.flexmark.html.LinkResolverFactory;
-import com.vladsch.flexmark.html.renderer.*;
-
-import java.util.Set;
-
-import static com.vladsch.flexmark.ext.wikilink.WikiLinkExtension.WIKI_LINK;
+import com.vladsch.flexmark.html.renderer.LinkResolverContext;
+import com.vladsch.flexmark.html.renderer.LinkStatus;
+import com.vladsch.flexmark.html.renderer.LinkType;
+import com.vladsch.flexmark.html.renderer.ResolvedLink;
 
 public class WikiLinkLinkResolver implements LinkResolver {
     private final WikiLinkOptions options;
@@ -24,13 +27,14 @@ public class WikiLinkLinkResolver implements LinkResolver {
             final boolean isWikiImage = node instanceof WikiImage;
             String wikiLink = link.getUrl();
             int iMax = wikiLink.length();
-            sb.append(isWikiImage ? options.imagePrefix : options.linkPrefix);
+            boolean absolute = iMax > 0 && wikiLink.charAt(0) == '/';
+            sb.append(isWikiImage ? options.getImagePrefix(absolute) : options.getLinkPrefix(absolute));
 
             boolean hadAnchorRef = false;
 
             String linkEscapeChars = options.linkEscapeChars;
             String linkReplaceChars = options.linkReplaceChars;
-            for (int i = 0; i < iMax; i++) {
+            for (int i = absolute ? 1 : 0; i < iMax; i++) {
                 char c = wikiLink.charAt(i);
 
                 if (c == '#') {

--- a/flexmark-ext-wikilink/src/main/java/com/vladsch/flexmark/ext/wikilink/internal/WikiLinkOptions.java
+++ b/flexmark-ext-wikilink/src/main/java/com/vladsch/flexmark/ext/wikilink/internal/WikiLinkOptions.java
@@ -13,8 +13,10 @@ public class WikiLinkOptions {
     public final boolean allowPipeEscape;
     public final String imageFileExtension;
     public final String imagePrefix;
+    public final String imagePrefixAbsolute;
     public final String linkFileExtension;
     public final String linkPrefix;
+    public final String linkPrefixAbsolute;
 	public final String linkReplaceChars;
 	public final String linkEscapeChars;
 
@@ -28,9 +30,19 @@ public class WikiLinkOptions {
         this.allowPipeEscape = WikiLinkExtension.ALLOW_PIPE_ESCAPE.getFrom(options);
         this.imageFileExtension = WikiLinkExtension.IMAGE_FILE_EXTENSION.getFrom(options);
         this.imagePrefix = WikiLinkExtension.IMAGE_PREFIX.getFrom(options);
+        this.imagePrefixAbsolute = WikiLinkExtension.IMAGE_PREFIX_ABSOLUTE.getFrom(options);
         this.linkFileExtension = WikiLinkExtension.LINK_FILE_EXTENSION.getFrom(options);
         this.linkPrefix = WikiLinkExtension.LINK_PREFIX.getFrom(options);
+        this.linkPrefixAbsolute = WikiLinkExtension.LINK_PREFIX_ABSOLUTE.getFrom(options);
         this.linkEscapeChars = WikiLinkExtension.LINK_ESCAPE_CHARS.getFrom(options);
         this.linkReplaceChars = WikiLinkExtension.LINK_REPLACE_CHARS.getFrom(options);
     }
+
+	public Object getLinkPrefix(boolean absolute) {
+		return absolute ? linkPrefixAbsolute : linkPrefix;
+	}
+
+	public Object getImagePrefix(boolean absolute) {
+		return absolute ? imagePrefixAbsolute : imagePrefix;
+	}
 }

--- a/flexmark-ext-wikilink/src/test/java/com/vladsch/flexmark/ext/wikilink/ComboWikiLinkSpecTest.java
+++ b/flexmark-ext-wikilink/src/test/java/com/vladsch/flexmark/ext/wikilink/ComboWikiLinkSpecTest.java
@@ -25,8 +25,10 @@ public class ComboWikiLinkSpecTest extends ComboSpecTestCase {
         optionsMap.put("links-first", new MutableDataSet().set(WikiLinkExtension.LINK_FIRST_SYNTAX, true));
         optionsMap.put("link-ext", new MutableDataSet().set(WikiLinkExtension.LINK_FILE_EXTENSION, ".html"));
         optionsMap.put("link-prefix", new MutableDataSet().set(WikiLinkExtension.LINK_PREFIX, "/prefix/"));
+        optionsMap.put("link-prefix-absolute", new MutableDataSet().set(WikiLinkExtension.LINK_PREFIX, "/relative/").set(WikiLinkExtension.LINK_PREFIX_ABSOLUTE, "/absolute/"));
         optionsMap.put("image-ext", new MutableDataSet().set(WikiLinkExtension.IMAGE_FILE_EXTENSION, ".png"));
         optionsMap.put("image-prefix", new MutableDataSet().set(WikiLinkExtension.IMAGE_PREFIX, "/images/"));
+        optionsMap.put("image-prefix-absolute", new MutableDataSet().set(WikiLinkExtension.IMAGE_PREFIX, "/relative/images/").set(WikiLinkExtension.IMAGE_PREFIX_ABSOLUTE, "/absolute/images/"));
         optionsMap.put("wiki-images", new MutableDataSet().set(WikiLinkExtension.IMAGE_LINKS, true));
         optionsMap.put("allow-inlines", new MutableDataSet().set(WikiLinkExtension.ALLOW_INLINES, true));
         optionsMap.put("allow-anchors", new MutableDataSet().set(WikiLinkExtension.ALLOW_ANCHORS, true));

--- a/flexmark-ext-wikilink/src/test/resources/ext_wikilink_ast_spec.md
+++ b/flexmark-ext-wikilink/src/test/resources/ext_wikilink_ast_spec.md
@@ -1198,6 +1198,70 @@ Document[0, 27]
 ````````````````````````````````
 
 
+Absolute link prefix
+
+```````````````````````````````` example(WikiLinks: 62) options(custom-link-escape,link-prefix-absolute)
+[[Page]]
+
+[[dir/Page]]
+
+[[/Page]]
+
+[[/dir/Page]]
+.
+<p><a href="/relative/Page">Page</a></p>
+<p><a href="/relative/dir/Page">dir/Page</a></p>
+<p><a href="/absolute/Page">/Page</a></p>
+<p><a href="/absolute/dir/Page">/dir/Page</a></p>
+.
+Document[0, 48]
+  Paragraph[0, 9] isTrailingBlankLine
+    WikiLink[0, 8] linkOpen:[0, 2, "[["] link:[2, 6, "Page"] pageRef:[2, 6, "Page"] linkClose:[6, 8, "]]"]
+      Text[2, 6] chars:[2, 6, "Page"]
+  Paragraph[10, 23] isTrailingBlankLine
+    WikiLink[10, 22] linkOpen:[10, 12, "[["] link:[12, 20, "dir/Page"] pageRef:[12, 20, "dir/Page"] linkClose:[20, 22, "]]"]
+      Text[12, 20] chars:[12, 20, "dir/Page"]
+  Paragraph[24, 34] isTrailingBlankLine
+    WikiLink[24, 33] linkOpen:[24, 26, "[["] link:[26, 31, "/Page"] pageRef:[26, 31, "/Page"] linkClose:[31, 33, "]]"]
+      Text[26, 31] chars:[26, 31, "/Page"]
+  Paragraph[35, 48]
+    WikiLink[35, 48] linkOpen:[35, 37, "[["] link:[37, 46, "/dir/Page"] pageRef:[37, 46, "/dir/Page"] linkClose:[46, 48, "]]"]
+      Text[37, 46] chars:[37, 46, "/dir/Page"]
+````````````````````````````````
+
+
+Absolute image prefix
+
+```````````````````````````````` example(WikiLinks: 63) options(wiki-images,custom-link-escape,image-prefix-absolute)
+![[Img]]
+
+![[dir/Img]]
+
+![[/Img]]
+
+![[/dir/Img]]
+.
+<p><img src="/relative/images/Img" alt="Img" /></p>
+<p><img src="/relative/images/dir/Img" alt="dir/Img" /></p>
+<p><img src="/absolute/images/Img" alt="/Img" /></p>
+<p><img src="/absolute/images/dir/Img" alt="/dir/Img" /></p>
+.
+Document[0, 48]
+  Paragraph[0, 9] isTrailingBlankLine
+    WikiImage[0, 8] linkOpen:[0, 3, "![["] link:[3, 6, "Img"] pageRef:[3, 6, "Img"] linkClose:[6, 8, "]]"]
+      Text[3, 6] chars:[3, 6, "Img"]
+  Paragraph[10, 23] isTrailingBlankLine
+    WikiImage[10, 22] linkOpen:[10, 13, "![["] link:[13, 20, "dir/Img"] pageRef:[13, 20, "dir/Img"] linkClose:[20, 22, "]]"]
+      Text[13, 20] chars:[13, 20, "dir/Img"]
+  Paragraph[24, 34] isTrailingBlankLine
+    WikiImage[24, 33] linkOpen:[24, 27, "![["] link:[27, 31, "/Img"] pageRef:[27, 31, "/Img"] linkClose:[31, 33, "]]"]
+      Text[27, 31] chars:[27, 31, "/Img"]
+  Paragraph[35, 48]
+    WikiImage[35, 48] linkOpen:[35, 38, "![["] link:[38, 46, "/dir/Img"] pageRef:[38, 46, "/dir/Img"] linkClose:[46, 48, "]]"]
+      Text[38, 46] chars:[38, 46, "/dir/Img"]
+````````````````````````````````
+
+
 ## Wiki Typographic Text
 
 With empty anchor ref

--- a/flexmark-util/src/main/java/com/vladsch/flexmark/util/options/DataKey.java
+++ b/flexmark-util/src/main/java/com/vladsch/flexmark/util/options/DataKey.java
@@ -14,6 +14,21 @@ public class DataKey<T> {
         this.factory = factory;
     }
 
+    /**
+     * Creates a {@link DataKey} with a dynamic fallback to the value of another key.
+     *
+     * @param name See {@link #getName()}.
+     * @param defaultKey The {@link DataKey} to take the default value from.
+     */
+    public DataKey(String name, final DataKey<? extends T> defaultKey) {
+    	this(name, new DataValueFactory<T>() {
+    		@Override
+    		public T create(DataHolder value) {
+    			return defaultKey.getFrom(value);
+    		}
+    	});
+    }
+    
     public DataKey(String name, final T defaultValue) {
         this.name = name;
         this.defaultValue = defaultValue;


### PR DESCRIPTION
In a wiki with virtual directories (see #186), it is natural to differentiate between absolute and relative links. On  a page `MyPage` in the virtual directory `my-dir` (accessible at `/my-dir/MyPage`), the link `MyImage` should be considered pointing to a resource in the same virtual directory `my-dir` (relative to the refering page accessible at `/my-dir/MyImage`). In contrast, a wiki link `/other-dir/MyImage` should be considered absolute  pointing to a resource at `/other-dir/MyImage`.

Added two new configuration options `IMAGE_PREFIX_ABSOLUTE` and `LINK_PREFIX_ABSOLUTE` that are used instead of `IMAGE_PREFIX` and `LINK_PREFIX` for absolute wiki images and links. By default, the new options default to `IMAGE_PREFIX` and `LINK_PREFIX`.
