### PR TITLE
Fix two small bugs in ext-toc

### DIFF
--- a/flexmark-ext-toc/src/main/java/com/vladsch/flexmark/ext/toc/internal/TocOptions.java
+++ b/flexmark-ext-toc/src/main/java/com/vladsch/flexmark/ext/toc/internal/TocOptions.java
@@ -47,7 +47,7 @@ public class TocOptions implements Immutable<TocOptions, TocOptions.AsMutable>, 
     }
 
     public TocOptions(int levels, boolean isHtml, boolean isTextOnly, boolean isNumbered, ListType listType) {
-        this(DEFAULT_LEVELS, false, false, false, DEFAULT_TITLE_LEVEL, DEFAULT_TITLE, listType, false, true);
+        this(levels, isHtml, isTextOnly, isNumbered, DEFAULT_TITLE_LEVEL, DEFAULT_TITLE, listType, false, true);
     }
 
     public TocOptions(int levels, boolean isHtml, boolean isTextOnly, boolean isNumbered, int titleLevel, String title, ListType listType) {

--- a/flexmark-ext-toc/src/main/java/com/vladsch/flexmark/ext/toc/internal/TocUtils.java
+++ b/flexmark-ext-toc/src/main/java/com/vladsch/flexmark/ext/toc/internal/TocUtils.java
@@ -325,7 +325,7 @@ public class TocUtils {
                     html.line();
                 }
             } else {
-                for (int lv = lastLevel; lv >= headerLevel + 1; lv++) {
+                for (int lv = lastLevel; lv >= headerLevel + 1; lv--) {
                     if (openedItems[lv]) {
                         html.unIndent();
                         listClose.run(lv);


### PR DESCRIPTION
- One of the constructors of TocOptions was using default values instead of the specified values.
- TocUtils::renderMarkdownToc had loop going in the wrong direction.