### PR TITLE
support Jira links titles

### DIFF
--- a/flexmark-jira-converter/src/main/java/com/vladsch/flexmark/jira/converter/internal/JiraConverterNodeRenderer.java
+++ b/flexmark-jira-converter/src/main/java/com/vladsch/flexmark/jira/converter/internal/JiraConverterNodeRenderer.java
@@ -418,7 +418,11 @@ public class JiraConverterNodeRenderer implements NodeRenderer
             ResolvedLink resolvedLink = context.resolveLink(LinkType.LINK, node.getUrl().unescape(), null);
             html.raw("[");
             context.renderChildren(node);
-            html.raw("|").raw(resolvedLink.getUrl()).raw("]");
+            html.raw("|").raw(resolvedLink.getUrl());
+            if (node.getTitle() != null && !node.getTitle().isEmpty()) {
+                html.raw("|").raw(node.getTitle());
+            }
+            html.raw("]");
         }
     }
 

--- a/flexmark-jira-converter/src/test/resources/jira_converter_ast_spec.md
+++ b/flexmark-jira-converter/src/test/resources/jira_converter_ast_spec.md
@@ -144,6 +144,19 @@ Document[0, 122]
 ````````````````````````````````
 
 
+```````````````````````````````` example Text formatting: 4
+[inline link with title](http://google.com "Google")
+.
+[inline link with title|http://google.com|Google]
+
+.
+Document[0, 53]
+  Paragraph[0, 53]
+    Link[0, 52] textOpen:[0, 1, "["] text:[1, 23, "inline link with title"] textClose:[23, 24, "]"] linkOpen:[24, 25, "("] url:[25, 42, "http://google.com"] pageRef:[25, 42, "http://google.com"] titleOpen:[43, 44, "\""] title:[44, 50, "Google"] titleClose:[50, 51, "\""] linkClose:[51, 52, ")"]
+      Text[1, 23] chars:[1, 23, "inlin … title"]
+````````````````````````````````
+
+
 ### Block quotes
 
 Single line block quote


### PR DESCRIPTION
Although [Jira wiki spec](https://jira.atlassian.com/secure/WikiRendererHelpAction.jspa?section=all)  doesn't say nothing about links titles, actually they support its.

This feature mentioned in Conluence docs (this is other Attlasian product with very close wiki markup support):
https://confluence.atlassian.com/doc/confluence-wiki-markup-251003035.html#ConfluenceWikiMarkup-Links :

> For each of these link forms:
> 
>    *You can prepend a link alias, so that alternate text is displayed on the page. Example: [link alias|pagetitle#anchor]
>    *You can append a link tip, which appears as a tooltip. Example: [pagetitle#anchor|link tip]

Of course, this PR can be declined because this is undocumented feature of JIRA wiki markup.
Actually I'm working on ConfluenceConverterNodeRenderer to support Confluence wiki markup. It's very close to Jira's with a few differences. 