### PR TITLE
Fix: CRLF line sepertor in fenced code blocks produce redundant CR.

### DIFF
--- a/flexmark-core-test/src/test/java/com/vladsch/flexmark/core/test/util/formatter/FormatterModifiedAST.java
+++ b/flexmark-core-test/src/test/java/com/vladsch/flexmark/core/test/util/formatter/FormatterModifiedAST.java
@@ -242,4 +242,36 @@ public class FormatterModifiedAST {
         //System.out.println("\n\nFormatted\n");
         //System.out.println(formatted);
     }
+
+    @Test
+    public void test_CRLFInFencedCodeBlock() throws Exception {
+
+        final String input =
+                "following sample:\n" +
+                "\n" +
+                "```xml\n" +
+                "<dependency>\r\n" +
+                "    <groupId>com.vladsch.flexmark</groupId>\r\n" +
+                "    <artifactId>flexmark-all</artifactId>\r\n" +
+                "    <version>0.60.2</version>\r\n" +
+                "</dependency>\r\n" +
+                "```\n\n";
+
+        final String expected =
+                "following sample:\n" +
+                "\n" +
+                "```xml\n" +
+                "<dependency>\r\n" +
+                "    <groupId>com.vladsch.flexmark</groupId>\r\n" +
+                "    <artifactId>flexmark-all</artifactId>\r\n" +
+                "    <version>0.60.2</version>\r\n" +
+                "</dependency>\r\n" +
+                "```\n\n";
+
+        Node document = PARSER.parse(input);
+
+        String formatted = RENDERER.render(document);
+
+        assertEquals(expected,formatted);
+    }
 }

--- a/flexmark-util-sequence/src/main/java/com/vladsch/flexmark/util/sequence/LineAppendableImpl.java
+++ b/flexmark-util-sequence/src/main/java/com/vladsch/flexmark/util/sequence/LineAppendableImpl.java
@@ -318,7 +318,8 @@ public class LineAppendableImpl implements LineAppendable {
         assert start <= end;
 
         CharSequence sequence = appendable.toSequence();
-        CharSequence text = start == Range.NULL.getStart() && end == Range.NULL.getEnd() ? BasedSequence.NULL : sequence.subSequence(start, end);
+        CharSequence text = start == Range.NULL.getStart() && end == Range.NULL.getEnd() ? BasedSequence.NULL :
+                (end - start) > 0 && sequence.charAt(end - 1) == '\r' ? sequence.subSequence(start, end - 1) : sequence.subSequence(start, end);
         CharSequence eol = trimmedEOL(sequence);
 
         if (eol == null || eol.length() == 0) {


### PR DESCRIPTION
Fix: #390  