### PR TITLE
Prevent StringIndexOutOfBounds in ext-resizable-image

### DIFF
--- a/flexmark-ext-resizable-image/src/main/java/com/vladsch/flexmark/ext/resizable/image/internal/ResizableImageInlineParserExtension.java
+++ b/flexmark-ext-resizable-image/src/main/java/com/vladsch/flexmark/ext/resizable/image/internal/ResizableImageInlineParserExtension.java
@@ -30,7 +30,11 @@ public class ResizableImageInlineParserExtension implements InlineParserExtensio
     @Override
     public boolean parse(@NotNull LightInlineParser inlineParser) {
         int index = inlineParser.getIndex();
-        char c = inlineParser.getInput().charAt(index + 1);
+        BasedSequence input = inlineParser.getInput();
+        if (index + 1 >= input.length()) {
+            return false;
+        }
+        char c = input.charAt(index + 1);
         if (c == '[') {
             BasedSequence[] matches = inlineParser.matchWithGroups(IMAGE_PATTERN);
             if (matches != null) {


### PR DESCRIPTION
Before this fix, input string `This is a test!` would throw:
```
java.lang.StringIndexOutOfBoundsException: String index: 16 out of range: [0, 16)
	at com.vladsch.flexmark.util.sequence.SequenceUtils.validateIndex(SequenceUtils.java:1143) ~[flexmark-util-sequence-0.64.0.jar:na]
	at com.vladsch.flexmark.util.sequence.SubSequence.charAt(SubSequence.java:113) ~[flexmark-util-sequence-0.64.0.jar:na]
	at com.vladsch.flexmark.ext.resizable.image.internal.ResizableImageInlineParserExtension.parse(ResizableImageInlineParserExtension.java:38) ~[classes/:na]
	at com.vladsch.flexmark.parser.internal.InlineParserImpl.parseInline(InlineParserImpl.java:368) ~[flexmark-0.64.0.jar:na]
	at com.vladsch.flexmark.parser.internal.InlineParserImpl.parse(InlineParserImpl.java:169) ~[flexmark-0.64.0.jar:na]
	at com.vladsch.flexmark.parser.core.ParagraphParser.parseInlines(ParagraphParser.java:64) ~[flexmark-0.64.0.jar:na]
	at com.vladsch.flexmark.parser.internal.DocumentParser.processInlines(DocumentParser.java:750) ~[flexmark-0.64.0.jar:na]
	at com.vladsch.flexmark.parser.internal.DocumentParser.finalizeAndProcess(DocumentParser.java:1005) ~[flexmark-0.64.0.jar:na]
	at com.vladsch.flexmark.parser.internal.DocumentParser.parse(DocumentParser.java:312) ~[flexmark-0.64.0.jar:na]
	at com.vladsch.flexmark.parser.Parser.parse(Parser.java:388) ~[flexmark-0.64.0.jar:na]
```
This PR introduces a range check before attempting to read the next char.