### PR TITLE
Add OSGi metadata to Manifest to enable deployment to OSGi environments

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,6 +130,18 @@
                     </descriptors>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-maven-plugin</artifactId>
+                <version>6.3.1</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>bnd-process</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
Flexmark is perhaps the most popular Java library for markdown processing, however it currently doesn't support OSGi metadata information to enable use in micro-kernel architectures.

This pull request proposed the addition of the [bnd](https://bndtools.org/) plugin to automatically generate OSGi metadata headers in the `MANIFEST.MF` file of each of the flexmark libraries, thus enabling their use in OSGi environments.
