### PR TITLE
Fix #548: Converting html images fails if the image refers to an emoji without a shortcut

### DIFF
--- a/flexmark-html2md-converter/src/main/java/com/vladsch/flexmark/html2md/converter/internal/HtmlConverterCoreNodeRenderer.java
+++ b/flexmark-html2md-converter/src/main/java/com/vladsch/flexmark/html2md/converter/internal/HtmlConverterCoreNodeRenderer.java
@@ -658,7 +658,7 @@ public class HtmlConverterCoreNodeRenderer implements PhasedHtmlNodeRenderer {
                 }
             }
 
-            if (emoji != null) {
+            if (emoji != null && emoji.shortcut != null) {
                 out.append(':').append(emoji.shortcut).append(':');
             } else {
                 LinkConversion conv = myHtmlConverterOptions.extInlineImage;

--- a/flexmark-html2md-converter/src/test/resources/html_converter_issue_spec.md
+++ b/flexmark-html2md-converter/src/test/resources/html_converter_issue_spec.md
@@ -1911,3 +1911,13 @@ Issue [#357, HTML to markdown and removed nested list]
 [#353, How to self modify parse method when htmltomarkdown]: https://github.com/vsch/flexmark-java/issues/353
 [#357, HTML to markdown and removed nested list]: https://github.com/vsch/flexmark-java/issues/357
 
+
+## Issue 548
+
+Issue #548 , Images with emoji-filenames break the emoji handling code if they have no corresponding shortcut
+
+```````````````````````````````` example Issue 548: 1
+![](1f9a0.png)
+.
+<img src="1f9a0.png" />
+````````````````````````````````


### PR DESCRIPTION
emojiReference.txt contains ~1000 emojis without shortcuts, but `HtmlConverterCoreNodeRenderer.java` made the incorrect assumption that every emoji had a shortcut, which broke converting certain `<img>` tags to Markdown.

PR includes a test case which illustrates the problem: the test will fail with an exception when the fix is not present.