### PR TITLE
Revert "Update CoreNodeRenderer.java"

### DIFF
--- a/flexmark/src/main/java/com/vladsch/flexmark/html/renderer/CoreNodeRenderer.java
+++ b/flexmark/src/main/java/com/vladsch/flexmark/html/renderer/CoreNodeRenderer.java
@@ -115,7 +115,7 @@ public class CoreNodeRenderer implements NodeRenderer {
 
     @SuppressWarnings("MethodMayBeStatic")
     void render(Heading node, NodeRendererContext context, HtmlWriter html) {
-        if (node.isExplicitAnchorRefId() || context.getHtmlOptions().renderHeaderId) {
+        if (context.getHtmlOptions().renderHeaderId) {
             String id = context.getNodeId(node);
             if (id != null) {
                 html.attr("id", id);


### PR DESCRIPTION
Reverts vsch/flexmark-java#534

After taking a closer look and running tests, I realized that this needs a bit of clarification.

Mainly, why do you not have `renderHeaderId`  option enabled? When rendering anchor links, header ids are not rendered because the id is transferred to the anchor link. Otherwise, you get two elements with the same ID.


