### PR TITLE
TextCollectingVisitor works better with code blocks

### DIFF
--- a/flexmark-core-test/src/test/java/com/vladsch/flexmark/core/test/util/parser/ast/TextCollectingVisitorTest.java
+++ b/flexmark-core-test/src/test/java/com/vladsch/flexmark/core/test/util/parser/ast/TextCollectingVisitorTest.java
@@ -91,4 +91,24 @@ public class TextCollectingVisitorTest {
                 "after" +
                 "", text);
     }
+
+    @Test
+    public void test_paragraph_and_indented_code_block() {
+        Parser parser = Parser.builder().build();
+        Node document = parser.parse("" +
+                "before\n" +
+                "\n" +
+                "    indented code block\n" +
+                "\n" +
+                "after");
+        TextCollectingVisitor collectingVisitor = new TextCollectingVisitor();
+        final String text = collectingVisitor.collectAndGetText(document);
+        assertEquals("" +
+                "before\n" +
+                "\n"+
+                "indented code block\n" +
+                "\n"+
+                "after" +
+                "", text);
+    }
 }

--- a/flexmark-core-test/src/test/java/com/vladsch/flexmark/core/test/util/parser/ast/TextCollectingVisitorTest.java
+++ b/flexmark-core-test/src/test/java/com/vladsch/flexmark/core/test/util/parser/ast/TextCollectingVisitorTest.java
@@ -67,4 +67,28 @@ public class TextCollectingVisitorTest {
                 "with more text" +
                 "", text);
     }
+
+    @Test
+    public void test_paragraph_and_fenced_code_block() {
+        Parser parser = Parser.builder().build();
+        Node document = parser.parse("" +
+                "before\n" +
+                "\n" +
+                "```\n" +
+                "fenced code\n" +
+                "block\n" +
+                "```\n" +
+                "\n" +
+                "after");
+        TextCollectingVisitor collectingVisitor = new TextCollectingVisitor();
+        final String text = collectingVisitor.collectAndGetText(document);
+        assertEquals("" +
+                "before\n" +
+                "\n"+
+                "fenced code\n" +
+                "block\n" +
+                "\n"+
+                "after" +
+                "", text);
+    }
 }

--- a/flexmark-util-ast/src/main/java/com/vladsch/flexmark/util/ast/TextCollectingVisitor.java
+++ b/flexmark-util-ast/src/main/java/com/vladsch/flexmark/util/ast/TextCollectingVisitor.java
@@ -16,6 +16,9 @@ public class TextCollectingVisitor {
             public void processNode(@NotNull Node node, boolean withChildren, @NotNull BiConsumer<Node, Visitor<Node>> processor) {
                 if (!node.isOrDescendantOfType(DoNotCollectText.class)) {
                     out.setLastNode(node);
+                    if (node instanceof Block && out.isNotEmpty()) {
+                        out.appendEol();
+                    }
                     if (node instanceof TextContainer) {
                         final TextContainer textContainer = (TextContainer) node;
                         if (textContainer.collectText(out, flags, myVisitor)) {
@@ -26,9 +29,6 @@ public class TextCollectingVisitor {
                         }
                         textContainer.collectEndText(out, flags, myVisitor);
                     } else {
-                        if (node instanceof BlankLineBreakNode && out.isNotEmpty()) {
-                            out.appendEol();
-                        }
                         processChildren(node, processor);
                     }
                     if (node instanceof LineBreakNode && out.needEol()) {

--- a/flexmark-util-ast/src/main/java/com/vladsch/flexmark/util/ast/TextCollectingVisitor.java
+++ b/flexmark-util-ast/src/main/java/com/vladsch/flexmark/util/ast/TextCollectingVisitor.java
@@ -17,12 +17,14 @@ public class TextCollectingVisitor {
                 if (!node.isOrDescendantOfType(DoNotCollectText.class)) {
                     out.setLastNode(node);
                     if (node instanceof TextContainer) {
-                        if (((TextContainer) node).collectText(out, flags, myVisitor)) {
+                        final TextContainer textContainer = (TextContainer) node;
+                        if (textContainer.collectText(out, flags, myVisitor)) {
                             if (node instanceof BlankLineBreakNode && out.isNotEmpty()) {
                                 out.appendEol();
                             }
                             processChildren(node, processor);
                         }
+                        textContainer.collectEndText(out, flags, myVisitor);
                     } else {
                         if (node instanceof BlankLineBreakNode && out.isNotEmpty()) {
                             out.appendEol();

--- a/flexmark-util-ast/src/main/java/com/vladsch/flexmark/util/ast/TextCollectingVisitor.java
+++ b/flexmark-util-ast/src/main/java/com/vladsch/flexmark/util/ast/TextCollectingVisitor.java
@@ -22,18 +22,15 @@ public class TextCollectingVisitor {
                                 out.appendEol();
                             }
                             processChildren(node, processor);
-                            if (node instanceof LineBreakNode && out.needEol()) {
-                                out.appendEol();
-                            }
                         }
                     } else {
                         if (node instanceof BlankLineBreakNode && out.isNotEmpty()) {
                             out.appendEol();
                         }
                         processChildren(node, processor);
-                        if (node instanceof LineBreakNode && out.needEol()) {
-                            out.appendEol();
-                        }
+                    }
+                    if (node instanceof LineBreakNode && out.needEol()) {
+                        out.appendEol();
                     }
                 }
             }

--- a/flexmark-util-ast/src/main/java/com/vladsch/flexmark/util/ast/TextCollectingVisitor.java
+++ b/flexmark-util-ast/src/main/java/com/vladsch/flexmark/util/ast/TextCollectingVisitor.java
@@ -15,8 +15,8 @@ public class TextCollectingVisitor {
             @Override
             public void processNode(@NotNull Node node, boolean withChildren, @NotNull BiConsumer<Node, Visitor<Node>> processor) {
                 if (!node.isOrDescendantOfType(DoNotCollectText.class)) {
+                    out.setLastNode(node);
                     if (node instanceof TextContainer) {
-                        out.setLastNode(node);
                         if (((TextContainer) node).collectText(out, flags, myVisitor)) {
                             if (node instanceof BlankLineBreakNode && out.isNotEmpty()) {
                                 out.appendEol();
@@ -27,7 +27,6 @@ public class TextCollectingVisitor {
                             }
                         }
                     } else {
-                        out.setLastNode(node);
                         if (node instanceof BlankLineBreakNode && out.isNotEmpty()) {
                             out.appendEol();
                         }

--- a/flexmark-util-ast/src/main/java/com/vladsch/flexmark/util/ast/TextContainer.java
+++ b/flexmark-util-ast/src/main/java/com/vladsch/flexmark/util/ast/TextContainer.java
@@ -53,4 +53,14 @@ public interface TextContainer {
      * @return true if child nodes should be visited
      */
     boolean collectText(ISequenceBuilder<? extends ISequenceBuilder<?, BasedSequence>, BasedSequence> out, int flags, NodeVisitor nodeVisitor);
+
+    /**
+     * Append node's text ending, after any child nodes have been visited.
+     * The default implementation does nothing.
+     *
+     * @param out   sequence build to which to append text
+     * @param flags collection flags
+     * @param nodeVisitor node visitor to use to visit children
+     */
+    default void collectEndText(ISequenceBuilder<? extends ISequenceBuilder<?, BasedSequence>, BasedSequence> out, int flags, NodeVisitor nodeVisitor) {}
 }

--- a/flexmark/src/main/java/com/vladsch/flexmark/ast/IndentedCodeBlock.java
+++ b/flexmark/src/main/java/com/vladsch/flexmark/ast/IndentedCodeBlock.java
@@ -2,12 +2,19 @@ package com.vladsch.flexmark.ast;
 
 import com.vladsch.flexmark.util.ast.Block;
 import com.vladsch.flexmark.util.ast.BlockContent;
+import com.vladsch.flexmark.util.ast.NodeVisitor;
+import com.vladsch.flexmark.util.ast.TextContainer;
 import com.vladsch.flexmark.util.sequence.BasedSequence;
+import com.vladsch.flexmark.util.sequence.Escaping;
+import com.vladsch.flexmark.util.sequence.ReplacedTextMapper;
+import com.vladsch.flexmark.util.sequence.builder.ISequenceBuilder;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 
-public class IndentedCodeBlock extends Block {
+import static com.vladsch.flexmark.util.misc.BitFieldSet.any;
+
+public class IndentedCodeBlock extends Block implements TextContainer {
 
     @NotNull
     @Override
@@ -28,5 +35,20 @@ public class IndentedCodeBlock extends Block {
 
     public IndentedCodeBlock(BlockContent blockContent) {
         super(blockContent);
+    }
+
+    @Override
+    public boolean collectText(ISequenceBuilder<? extends ISequenceBuilder<?, BasedSequence>, BasedSequence> out, int flags, NodeVisitor nodeVisitor) {
+        final BasedSequence chars = getContentChars();
+        if (any(flags, F_NODE_TEXT)) {
+            out.append(chars);
+        } else {
+            ReplacedTextMapper textMapper = new ReplacedTextMapper(chars);
+            BasedSequence unescaped = Escaping.unescape(chars, textMapper);
+            if (!unescaped.isEmpty()) {
+                out.append(unescaped);
+            }
+        }
+        return false;
     }
 }

--- a/flexmark/src/main/java/com/vladsch/flexmark/ast/Paragraph.java
+++ b/flexmark/src/main/java/com/vladsch/flexmark/ast/Paragraph.java
@@ -136,8 +136,16 @@ public class Paragraph extends Block implements TextContainer {
     @Override
     public boolean collectText(ISequenceBuilder<? extends ISequenceBuilder<?, BasedSequence>, BasedSequence> out, int flags, NodeVisitor nodeVisitor) {
         if (!out.isEmpty()) {
-            out.add("\n\n");
+            out.add("\n");
         }
+
         return true;
+    }
+
+    @Override
+    public void collectEndText(ISequenceBuilder<? extends ISequenceBuilder<?, BasedSequence>, BasedSequence> out, int flags, NodeVisitor nodeVisitor) {
+        if (trailingBlankLine) {
+            out.add("\n");
+        }
     }
 }

--- a/flexmark/src/main/java/com/vladsch/flexmark/ast/Paragraph.java
+++ b/flexmark/src/main/java/com/vladsch/flexmark/ast/Paragraph.java
@@ -135,10 +135,6 @@ public class Paragraph extends Block implements TextContainer {
 
     @Override
     public boolean collectText(ISequenceBuilder<? extends ISequenceBuilder<?, BasedSequence>, BasedSequence> out, int flags, NodeVisitor nodeVisitor) {
-        if (!out.isEmpty()) {
-            out.add("\n");
-        }
-
         return true;
     }
 


### PR DESCRIPTION
Changes, with unit tests where appropriate:

1. Refactored `TextCollectingVisitor` to avoid duplicate code
2. `TextContainer` has a new `collectEndText(..)` method allowing `Paragraph` to append it's optional trailing line break
3. Consistently add a blank line before all (non-first) `Block` text (implicitly including `FencedCodeBlock`, no longer relying on `Paragraph` special case)
4. `IndentedCodeBlock` implements `TextContainer` and collects content chars.

Closes #574