### PR TITLE
Fix handling of emphasis + strong

### DIFF
--- a/flexmark/src/main/java/com/vladsch/flexmark/parser/core/delimiter/EmphasisDelimiterProcessor.java
+++ b/flexmark/src/main/java/com/vladsch/flexmark/parser/core/delimiter/EmphasisDelimiterProcessor.java
@@ -58,6 +58,9 @@ public abstract class EmphasisDelimiterProcessor implements DelimiterProcessor {
     public int getDelimiterUse(DelimiterRun opener, DelimiterRun closer) {
         // "multiple of 3" rule for internal delimiter runs
         if ((opener.canClose() || closer.canOpen()) && (opener.length() + closer.length()) % 3 == 0) {
+            if (opener.length() % 3 == 0 && closer.length() % 3 == 0) {
+                return this.multipleUse; // if they are each a multiple of 3, then emphasis can be created
+            }
             return 0;
         }
 


### PR DESCRIPTION
Adjusted the use of delimiters to allow the triple case to work [per CommonMark](https://spec.commonmark.org/0.29/#example-415).

The original logic didn't support the case where both the opener and closer are multiples of 3 to allow emphasis.

I added support for use of `multipleUse` to drive which amount is taken first.

Resolves #557