### PR TITLE
add inline parsing for admonition titles to enable formatting

### DIFF
--- a/flexmark-ext-admonition/src/main/java/com/vladsch/flexmark/ext/admonition/AdmonitionBlock.java
+++ b/flexmark-ext-admonition/src/main/java/com/vladsch/flexmark/ext/admonition/AdmonitionBlock.java
@@ -3,8 +3,10 @@ package com.vladsch.flexmark.ext.admonition;
 import com.vladsch.flexmark.ast.Paragraph;
 import com.vladsch.flexmark.ast.ParagraphContainer;
 import com.vladsch.flexmark.util.ast.Block;
+import com.vladsch.flexmark.util.ast.Node;
 import com.vladsch.flexmark.util.sequence.BasedSequence;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
@@ -14,31 +16,13 @@ import java.util.List;
 public class AdmonitionBlock extends Block implements ParagraphContainer {
     private BasedSequence openingMarker = BasedSequence.NULL;
     private BasedSequence info = BasedSequence.NULL;
-    protected BasedSequence titleOpeningMarker = BasedSequence.NULL;
-    protected BasedSequence title = BasedSequence.NULL;
-    protected BasedSequence titleClosingMarker = BasedSequence.NULL;
 
     @NotNull
     @Override
     public BasedSequence[] getSegments() {
         return new BasedSequence[] {
                 openingMarker,
-                info,
-                titleOpeningMarker,
-                title,
-                titleClosingMarker,
-        };
-    }
-
-    @NotNull
-    @Override
-    public BasedSequence[] getSegmentsForChars() {
-        return new BasedSequence[] {
-                openingMarker,
-                info,
-                titleOpeningMarker,
-                title,
-                titleClosingMarker,
+                info
         };
     }
 
@@ -46,7 +30,6 @@ public class AdmonitionBlock extends Block implements ParagraphContainer {
     public void getAstExtra(@NotNull StringBuilder out) {
         segmentSpanChars(out, openingMarker, "open");
         segmentSpanChars(out, info, "info");
-        delimitedSegmentSpanChars(out, titleOpeningMarker, title, titleClosingMarker, "title");
     }
 
     public AdmonitionBlock() {
@@ -78,45 +61,32 @@ public class AdmonitionBlock extends Block implements ParagraphContainer {
         return info;
     }
 
+    @Nullable
+    public AdmonitionTitle getTitleNode() {
+        Node child = getFirstChild();
+        if (child instanceof AdmonitionTitle)
+            return (AdmonitionTitle) child;
+        return null;
+    }
+
     public BasedSequence getTitle() {
-        return title;
+        AdmonitionTitle title = getTitleNode();
+        return title == null ? BasedSequence.NULL : title.getText();
     }
 
     public BasedSequence getTitleOpeningMarker() {
-        return titleOpeningMarker;
-    }
-
-    public void setTitleOpeningMarker(BasedSequence titleOpeningMarker) {
-        this.titleOpeningMarker = titleOpeningMarker;
-    }
-
-    public void setTitle(BasedSequence title) {
-        this.title = title;
+        AdmonitionTitle title = getTitleNode();
+        return title == null ? BasedSequence.NULL : title.getOpeningMarker();
     }
 
     public BasedSequence getTitleClosingMarker() {
-        return titleClosingMarker;
-    }
-
-    public void setTitleClosingMarker(BasedSequence titleClosingMarker) {
-        this.titleClosingMarker = titleClosingMarker;
+        AdmonitionTitle title = getTitleNode();
+        return title == null ? BasedSequence.NULL : title.getClosingMarker();
     }
 
     public BasedSequence getTitleChars() {
-        return spanningChars(titleOpeningMarker, title, titleClosingMarker);
-    }
-
-    public void setTitleChars(BasedSequence titleChars) {
-        if (titleChars != null && titleChars != BasedSequence.NULL) {
-            int titleCharsLength = titleChars.length();
-            titleOpeningMarker = titleChars.subSequence(0, 1);
-            title = titleChars.subSequence(1, titleCharsLength - 1);
-            titleClosingMarker = titleChars.subSequence(titleCharsLength - 1, titleCharsLength);
-        } else {
-            titleOpeningMarker = BasedSequence.NULL;
-            title = BasedSequence.NULL;
-            titleClosingMarker = BasedSequence.NULL;
-        }
+        AdmonitionTitle title = getTitleNode();
+        return title == null ? BasedSequence.NULL : title.getChars();
     }
 
     @Override

--- a/flexmark-ext-admonition/src/main/java/com/vladsch/flexmark/ext/admonition/AdmonitionTitle.java
+++ b/flexmark-ext-admonition/src/main/java/com/vladsch/flexmark/ext/admonition/AdmonitionTitle.java
@@ -1,0 +1,6 @@
+package com.vladsch.flexmark.ext.admonition;
+
+import com.vladsch.flexmark.ast.DelimitedNodeImpl;
+
+public class AdmonitionTitle extends DelimitedNodeImpl {
+}

--- a/flexmark-ext-admonition/src/main/java/com/vladsch/flexmark/ext/admonition/internal/AdmonitionBlockParser.java
+++ b/flexmark-ext-admonition/src/main/java/com/vladsch/flexmark/ext/admonition/internal/AdmonitionBlockParser.java
@@ -3,6 +3,8 @@ package com.vladsch.flexmark.ext.admonition.internal;
 import com.vladsch.flexmark.ast.ListItem;
 import com.vladsch.flexmark.ast.util.Parsing;
 import com.vladsch.flexmark.ext.admonition.AdmonitionBlock;
+import com.vladsch.flexmark.ext.admonition.AdmonitionTitle;
+import com.vladsch.flexmark.parser.InlineParser;
 import com.vladsch.flexmark.parser.block.*;
 import com.vladsch.flexmark.util.ast.Block;
 import com.vladsch.flexmark.util.data.DataHolder;
@@ -69,6 +71,15 @@ public class AdmonitionBlockParser extends AbstractBlockParser {
     @Override
     public void closeBlock(ParserState state) {
         block.setCharsFromContent();
+    }
+
+    @Override
+    public void parseInlines(InlineParser inlineParser) {
+        super.parseInlines(inlineParser);
+        AdmonitionTitle title = block.getTitleNode();
+        if (title != null) {
+            inlineParser.parse(title.getText(), title);
+        }
     }
 
     public static class Factory implements CustomBlockParserFactory {
@@ -185,7 +196,14 @@ public class AdmonitionBlockParser extends AbstractBlockParser {
                     AdmonitionBlockParser admonitionBlockParser = new AdmonitionBlockParser(options, contentOffset);
                     admonitionBlockParser.block.setOpeningMarker(openingMarker);
                     admonitionBlockParser.block.setInfo(info);
-                    admonitionBlockParser.block.setTitleChars(titleChars);
+                    if (titleChars.isNotNull()) {
+                        AdmonitionTitle title = new AdmonitionTitle();
+                        title.setOpeningMarker(titleChars.subSequence(0, 1));
+                        title.setText(titleChars.subSequence(1, titleChars.length() - 1));
+                        title.setClosingMarker(titleChars.subSequence(titleChars.length() - 1));
+                        title.setCharsFromSegments();
+                        admonitionBlockParser.block.prependChild(title);
+                    }
 
                     return BlockStart.of(admonitionBlockParser)
                             .atIndex(line.length());

--- a/flexmark-ext-admonition/src/main/java/com/vladsch/flexmark/ext/admonition/internal/AdmonitionNodeRenderer.java
+++ b/flexmark-ext-admonition/src/main/java/com/vladsch/flexmark/ext/admonition/internal/AdmonitionNodeRenderer.java
@@ -1,9 +1,11 @@
 package com.vladsch.flexmark.ext.admonition.internal;
 
 import com.vladsch.flexmark.ext.admonition.AdmonitionBlock;
+import com.vladsch.flexmark.ext.admonition.AdmonitionTitle;
 import com.vladsch.flexmark.html.HtmlWriter;
 import com.vladsch.flexmark.html.renderer.*;
 import com.vladsch.flexmark.util.ast.Document;
+import com.vladsch.flexmark.util.ast.Node;
 import com.vladsch.flexmark.util.data.DataHolder;
 import com.vladsch.flexmark.util.html.Attribute;
 import org.jetbrains.annotations.NotNull;
@@ -31,6 +33,7 @@ public class AdmonitionNodeRenderer implements PhasedNodeRenderer {
     public Set<NodeRenderingHandler<?>> getNodeRenderingHandlers() {
         Set<NodeRenderingHandler<?>> set = new HashSet<>();
         set.add(new NodeRenderingHandler<>(AdmonitionBlock.class, this::render));
+        set.add(new NodeRenderingHandler<>(AdmonitionTitle.class, this::render));
         return set;
     }
 
@@ -71,6 +74,23 @@ public class AdmonitionNodeRenderer implements PhasedNodeRenderer {
         }
     }
 
+    private static void outputTitle(String type, HtmlWriter html, Runnable output) {
+        html.attr(Attribute.CLASS_ATTR, "adm-heading").withAttr(ADMONITION_HEADING_PART).tag("div").line();
+        html.attr(Attribute.CLASS_ATTR, "adm-icon").withAttr(ADMONITION_ICON_PART).tag("svg").raw("<use xlink:href=\"#adm-").raw(type).raw("\" />").closeTag("svg");
+        html.withAttr(ADMONITION_TITLE_PART).tag("span", output);
+        html.closeTag("div").line();
+    }
+
+    private void render(AdmonitionTitle node, NodeRendererContext context, HtmlWriter html) {
+        if (node.getText().isEmpty()) return;
+        String type = options.unresolvedQualifier;
+        if (node.getParent() instanceof AdmonitionBlock) {
+            type = ((AdmonitionBlock) node.getParent()).getInfo().toString().toLowerCase();
+            type = this.options.qualifierTypeMap.getOrDefault(type, options.unresolvedQualifier);
+        }
+        outputTitle(type, html, () -> context.renderChildren(node));
+    }
+
     private void render(AdmonitionBlock node, NodeRendererContext context, HtmlWriter html) {
         String info = node.getInfo().toString().toLowerCase();
         String type = this.options.qualifierTypeMap.get(info);
@@ -78,51 +98,41 @@ public class AdmonitionNodeRenderer implements PhasedNodeRenderer {
             type = options.unresolvedQualifier;
         }
 
-        String title;
-        if (node.getTitle().isNull()) {
-            title = this.options.qualifierTitleMap.get(info);
-            if (title == null) {
-                title = info.substring(0, 1).toUpperCase() + info.substring(1);
-            }
-        } else {
-            title = node.getTitle().toString();
-        }
-
         String openClose;
         if (node.getOpeningMarker().equals("???")) openClose = " adm-collapsed";
         else if (node.getOpeningMarker().equals("???+")) openClose = "adm-open";
         else openClose = null;
 
-        if (title.isEmpty()) {
-            html.srcPos(node.getChars()).withAttr()
-                    .attr(Attribute.CLASS_ATTR, "adm-block")
-                    .attr(Attribute.CLASS_ATTR, "adm-" + type)
-                    .tag("div", false).line();
-
-            html.attr(Attribute.CLASS_ATTR, "adm-body").withAttr(ADMONITION_BODY_PART).tag("div").indent().line();
-
-            context.renderChildren(node);
-
-            html.unIndent().closeTag("div").line();
-            html.closeTag("div").line();
-        } else {
-            html.srcPos(node.getChars())
-                    .attr(Attribute.CLASS_ATTR, "adm-block").attr(Attribute.CLASS_ATTR, "adm-" + type);
-
-            if (openClose != null) {
-                html.attr(Attribute.CLASS_ATTR, openClose).attr(Attribute.CLASS_ATTR, "adm-" + type);
-            }
-
-            html.withAttr().tag("div", false).line();
-            html.attr(Attribute.CLASS_ATTR, "adm-heading").withAttr(ADMONITION_HEADING_PART).tag("div").line();
-            html.attr(Attribute.CLASS_ATTR, "adm-icon").withAttr(ADMONITION_ICON_PART).tag("svg").raw("<use xlink:href=\"#adm-").raw(type).raw("\" />").closeTag("svg");
-            html.withAttr(ADMONITION_TITLE_PART).tag("span").text(title).closeTag("span").line();
-            html.closeTag("div").line();
-
-            html.attr(Attribute.CLASS_ATTR, "adm-body").withAttr(ADMONITION_BODY_PART).withCondIndent().tagLine("div", () -> context.renderChildren(node));
-
-            html.closeTag("div").line();
+        html.srcPos(node.getChars()).withAttr()
+                .attr(Attribute.CLASS_ATTR, "adm-block")
+                .attr(Attribute.CLASS_ATTR, "adm-" + type);
+        if (openClose != null) {
+            html.attr(Attribute.CLASS_ATTR, openClose);
         }
+        html.tag("div", false).line();
+
+        AdmonitionTitle title = node.getTitleNode();
+
+        if (title == null) { // standard title
+            outputTitle(type, html, () -> {
+                String automaticTitle = this.options.qualifierTitleMap.get(info);
+                if (automaticTitle == null)
+                    automaticTitle = info.substring(0, 1).toUpperCase() + info.substring(1);
+                html.text(automaticTitle);
+            });
+        } else if (!title.getText().isEmpty()) {
+            outputTitle(type, html, () -> context.renderChildren(title));
+        }
+
+        html.attr(Attribute.CLASS_ATTR, "adm-body").withAttr(ADMONITION_BODY_PART).tag("div").indent().line();
+        Node next = title == null ? node.getFirstChild() : title.getNext();
+        while (next != null) {
+            Node child = next;
+            next = child.getNext();
+            context.render(child);
+        }
+        html.unIndent().closeTag("div").line();
+        html.closeTag("div").line();
     }
 
     public static class Factory implements NodeRendererFactory {


### PR DESCRIPTION
This change enables inline formatting in admonitions.
For this a new `AdmonitionTitle` node is introduced as the first child of an `AdmonitionBlock`.
I'm not happy about the inlined `visitChildren` in both renderer and formatter to skip over the title node.

Any hints for improvement?

```markdown
!!! info "Test *inline* `formatting` for [admonition titles](https://github.com/vsch/flexmark-java/wiki/Extensions#admonition)"
    This change enables inline formatting in admonitions.
```
