### PR TITLE
Fix wrong closing bracket

### DIFF
--- a/flexmark-ext-resizable-image/src/main/java/com/vladsch/flexmark/ext/resizable/image/internal/ResizableImageInlineParserExtension.java
+++ b/flexmark-ext-resizable-image/src/main/java/com/vladsch/flexmark/ext/resizable/image/internal/ResizableImageInlineParserExtension.java
@@ -13,7 +13,7 @@ import java.util.Set;
 import java.util.regex.Pattern;
 
 public class ResizableImageInlineParserExtension implements InlineParserExtension {
-    final public static Pattern IMAGE_PATTERN = Pattern.compile("\\!\\[([^\\s\\]]*)]\\(([^\\s\\]]+)\\s*=*(\\d*)x*(\\d*)\\)",
+    final public static Pattern IMAGE_PATTERN = Pattern.compile("\\!\\[([^\\s\\]]*)]\\(([^\\s\\)]+)\\s*=*(\\d*)x*(\\d*)\\)",
             Pattern.CASE_INSENSITIVE);
 
     public ResizableImageInlineParserExtension(LightInlineParser inlineParser) {


### PR DESCRIPTION
`![Test](Test) =16x16)` is entirely matched by the pattern but I expect that only `![Test](Test)` refers to the image.

On the other hand `![Test](Test] =16x16)` would not match while `![Test](Test])` is the way to embed the image named `Test]`.
