### PR TITLE
Fix abbreviations matching with Java 19+

### DIFF
--- a/flexmark-ext-abbreviation/src/main/java/com/vladsch/flexmark/ext/abbreviation/internal/AbbreviationNodePostProcessor.java
+++ b/flexmark-ext-abbreviation/src/main/java/com/vladsch/flexmark/ext/abbreviation/internal/AbbreviationNodePostProcessor.java
@@ -57,7 +57,7 @@ public class AbbreviationNodePostProcessor extends NodePostProcessor {
                 }
             }
 
-            if (sb.length() > 0) this.abbreviations = Pattern.compile(sb.toString());
+            if (sb.length() > 0) this.abbreviations = Pattern.compile(sb.toString(), Pattern.UNICODE_CHARACTER_CLASS);
         }
     }
 


### PR DESCRIPTION
In order for regex `\b` character class to match non-ASCII characters the UNICODE_CHARACTER_CLASS flag must be passed to regex compiler.

See https://bugs.openjdk.org/browse/JDK-8291577

Fixes #632