### PR TITLE
Fix index out of bounds exception for HTML tables

### DIFF
--- a/flexmark-html2md-converter/src/test/resources/flexmark_html_converter_spec.md
+++ b/flexmark-html2md-converter/src/test/resources/flexmark_html_converter_spec.md
@@ -3010,6 +3010,25 @@ tables with row span cells
 ````````````````````````````````
 
 
+table where some rows end with colspan 0
+
+```````````````````````````````` example Tables: 51
+|   Abc   | Def |
+|---------|-----|
+| no span | span 
+
+.
+<table>
+  <thead>
+    <tr><th>Abc</th><th colspan="1">Def</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>no span</td><td colspan="0">span</td></tr>
+  </tbody>
+</table>
+````````````````````````````````
+
+
 ## Definition Lists
 
 a definition in a block quote

--- a/flexmark-html2md-converter/src/test/resources/flexmark_html_converter_spec.md
+++ b/flexmark-html2md-converter/src/test/resources/flexmark_html_converter_spec.md
@@ -3029,6 +3029,25 @@ table where some rows end with colspan 0
 ````````````````````````````````
 
 
+table where all rows end with colspan 0
+
+```````````````````````````````` example Tables: 52
+|   Abc   | Def  
+|---------|-----|
+| no span | span 
+
+.
+<table>
+  <thead>
+    <tr><th>Abc</th><th colspan="0">Def</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>no span</td><td colspan="0">span</td></tr>
+  </tbody>
+</table>
+````````````````````````````````
+
+
 ## Definition Lists
 
 a definition in a block quote

--- a/flexmark-util-format/src/main/java/com/vladsch/flexmark/util/format/TableRow.java
+++ b/flexmark-util-format/src/main/java/com/vladsch/flexmark/util/format/TableRow.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static com.vladsch.flexmark.util.format.TableCellManipulator.BREAK;
+import static com.vladsch.flexmark.util.misc.Utils.max;
 import static com.vladsch.flexmark.util.misc.Utils.maxLimit;
 import static com.vladsch.flexmark.util.misc.Utils.minLimit;
 
@@ -97,7 +98,7 @@ public class TableRow {
         int columns = 0;
         for (TableCell cell : cells) {
             if (cell == null) continue;
-            columns += cell.columnSpan;
+            columns += max(cell.columnSpan, 1);
         }
         return columns;
     }


### PR DESCRIPTION
The exception occurred when each row ended with a cell with the attribute  with colspan="0", as shown in the tests.
This should fix issue #609 