### PR TITLE
Set org.jetbrains:annotations scope to provided

### DIFF
--- a/flexmark-util-ast/pom.xml
+++ b/flexmark-util-ast/pom.xml
@@ -46,6 +46,7 @@
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
             <version>24.0.1</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Per https://github.com/JetBrains/java-annotations it should be set to scope provided to avoid being picked transitively