### PR TITLE
Fix/stack over flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,9 @@ target/
 /assets/comms/
 /lib/
 /mvn-dependency-tree.txt
+
+# local
+.vscode/
+.DS_Store
+.devcontainer/
+.claude/

--- a/flexmark-core-test/src/test/java/com/vladsch/flexmark/core/test/util/parser/SpecialInputTest.java
+++ b/flexmark-core-test/src/test/java/com/vladsch/flexmark/core/test/util/parser/SpecialInputTest.java
@@ -136,9 +136,9 @@ final public class SpecialInputTest extends RenderingTestCase {
 
     @Test
     public void hugeDataUrlInLink() {
-        String url = "https://example.com/" + "A".repeat(5000);
-        String markdown = "[link]: <" + url + ">";
-        assertRendering(markdown, "<a href=\"" + url + "\">link</a>");
+        String url = "data:image/jpeg;base64," + "A".repeat(5000);
+        String markdown = "![alt text][image]\n\n[image]: <" + url + ">";
+        assertRendering(markdown, "<p><img src=\"" + url + "\" alt=\"alt text\" /></p>");
     }
 
     @Nullable

--- a/flexmark-core-test/src/test/java/com/vladsch/flexmark/core/test/util/parser/SpecialInputTest.java
+++ b/flexmark-core-test/src/test/java/com/vladsch/flexmark/core/test/util/parser/SpecialInputTest.java
@@ -131,7 +131,7 @@ final public class SpecialInputTest extends RenderingTestCase {
 
     @Test
     public void uncompletedHugeHtmlTag() {
-        assertRendering("<" + Strings.repeat("a", 1000000), "&lt;" + Strings.repeat("a", 1000000));
+        assertRendering("<" + Strings.repeat("a", 1000000), "<p>&lt;" + Strings.repeat("a", 1000000) + "</p>\n");
     }
 
     @Test

--- a/flexmark-core-test/src/test/java/com/vladsch/flexmark/core/test/util/parser/SpecialInputTest.java
+++ b/flexmark-core-test/src/test/java/com/vladsch/flexmark/core/test/util/parser/SpecialInputTest.java
@@ -1,15 +1,20 @@
 package com.vladsch.flexmark.core.test.util.parser;
 
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.junit.Test;
+
 import com.vladsch.flexmark.html.HtmlRenderer;
 import com.vladsch.flexmark.parser.Parser;
-import com.vladsch.flexmark.test.util.*;
+import com.vladsch.flexmark.test.util.FlexmarkSpecExampleRenderer;
+import com.vladsch.flexmark.test.util.RenderingTestCase;
+import com.vladsch.flexmark.test.util.SpecExampleRenderer;
+import com.vladsch.flexmark.test.util.Strings;
+import com.vladsch.flexmark.test.util.TestUtils;
 import com.vladsch.flexmark.test.util.spec.SpecExample;
 import com.vladsch.flexmark.util.data.DataHolder;
 import com.vladsch.flexmark.util.data.DataSet;
 import com.vladsch.flexmark.util.data.MutableDataSet;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-import org.junit.Test;
 
 final public class SpecialInputTest extends RenderingTestCase {
     final private static DataHolder OPTIONS = new MutableDataSet()
@@ -121,7 +126,19 @@ final public class SpecialInputTest extends RenderingTestCase {
 
     @Test
     public void manyUnderscores() {
-        assertRendering(Strings.repeat("_", 1000), "<hr />");
+        assertRendering(Strings.repeat("_", 100000), "<hr />");
+    }
+
+    @Test
+    public void uncompletedHugeHtmlTag() {
+        assertRendering("<" + Strings.repeat("a", 1000000), "&lt;" + Strings.repeat("a", 1000000));
+    }
+
+    @Test
+    public void hugeDataUrlInLink() {
+        String url = "https://example.com/" + "A".repeat(5000);
+        String markdown = "[link]: <" + url + ">";
+        assertRendering(markdown, "<a href=\"" + url + "\">link</a>");
     }
 
     @Nullable

--- a/flexmark/src/main/java/com/vladsch/flexmark/ast/util/Parsing.java
+++ b/flexmark/src/main/java/com/vladsch/flexmark/ast/util/Parsing.java
@@ -24,7 +24,8 @@ public class Parsing {
 //    final public static String XML_NAMESPACE_CHAR = XML_NAME_SPACE_START + "|-|.|[0-9]";
     final public static String XML_NAMESPACE_START = "[_A-Za-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD]"; // excluded  [#x10000-#xEFFFF]
     final public static String XML_NAMESPACE_CHAR = XML_NAMESPACE_START + "|[.0-9\u00B7\u0300-\u036F\u203F-\u2040-]";
-    final public static String XML_NAMESPACE = "(?:(?:" + XML_NAMESPACE_START + ")(?:" + XML_NAMESPACE_CHAR + ")*:)?";
+    // NOTE: Set name length limit to avoid stack overflow on pathological cases
+    final public static String XML_NAMESPACE = "(?:(?:" + XML_NAMESPACE_START + ")(?:" + XML_NAMESPACE_CHAR + "){0,200}:)?";
 
     // save options for others to use when only parsing instance is available
     final public DataHolder options;

--- a/flexmark/src/main/java/com/vladsch/flexmark/parser/internal/InlineParserImpl.java
+++ b/flexmark/src/main/java/com/vladsch/flexmark/parser/internal/InlineParserImpl.java
@@ -3,6 +3,7 @@ package com.vladsch.flexmark.parser.internal;
 import com.vladsch.flexmark.ast.*;
 import com.vladsch.flexmark.ast.util.ReferenceRepository;
 import com.vladsch.flexmark.ast.util.TextNodeConverter;
+import com.vladsch.flexmark.ast.util.Parsing;
 import com.vladsch.flexmark.parser.*;
 import com.vladsch.flexmark.parser.block.CharacterNodeFactory;
 import com.vladsch.flexmark.parser.block.ParagraphPreProcessor;
@@ -1181,8 +1182,10 @@ public class InlineParserImpl extends LightInlineParserImpl implements InlinePar
      */
     @Override
     public BasedSequence parseLinkDestination() {
-        BasedSequence res = match(myParsing.LINK_DESTINATION_ANGLES);
+        // NOTE: Use linear parser to prevent StackOverflowError on large URLs
+        BasedSequence res = Parsing.parseAngledLinkDestination(input, index, options.spaceInLinkUrls);
         if (res != null) {
+            index += res.length();
             return res;
         } else {
             if (linkDestinationParser != null) {

--- a/flexmark/src/main/java/com/vladsch/flexmark/parser/internal/LinkDestinationParser.java
+++ b/flexmark/src/main/java/com/vladsch/flexmark/parser/internal/LinkDestinationParser.java
@@ -100,6 +100,12 @@ public class LinkDestinationParser {
 
     public BasedSequence parseLinkDestination(BasedSequence input, int startIndex) {
         int iMax = input.length();
+
+        // Handle angled link destination to prevent StackOverflowError
+        if (startIndex < iMax && input.charAt(startIndex) == '<') {
+            return parseAngledLinkDestination(input, startIndex);
+        }
+
         int lastMatch = startIndex;
 
         int openParenCount = 0;
@@ -282,5 +288,64 @@ public class LinkDestinationParser {
             charSet.set(i);
         }
         return charSet;
+    }
+
+    /**
+     * Parse angled link destination without regex catastrophic backtracking.
+     * Replaces regex-based parsing to prevent StackOverflowError on large URLs.
+     *
+     * @param input the input sequence
+     * @param startIndex starting position
+     * @return parsed result or null if no match
+     */
+    private BasedSequence parseAngledLinkDestination(BasedSequence input, int startIndex) {
+        if (startIndex >= input.length() || input.charAt(startIndex) != '<') {
+            return null;
+        }
+
+        int pos = startIndex + 1;
+
+        while (pos < input.length()) {
+            char c = input.charAt(pos);
+
+            // End of angled destination
+            if (c == '>') {
+                return input.subSequence(startIndex, pos + 1);
+            }
+
+            // Invalid characters
+            if (c == '<' || c == '\0' || c == '\t' || c == '\n' || c == '\r') {
+                return null;
+            }
+
+            // Space handling
+            if (c == ' ') {
+                if (!spaceInUrls) {
+                    return null;
+                }
+                // Check lookahead for space followed by quote
+                if (pos + 1 < input.length()) {
+                    char next = input.charAt(pos + 1);
+                    if (next == '"' || next == '\'') {
+                        return null;
+                    }
+                }
+            }
+
+            // Escape sequence handling
+            if (c == '\\') {
+                pos++; // Skip the backslash
+                if (pos >= input.length()) {
+                    return null; // Incomplete escape at end
+                }
+                // The next character is consumed regardless of whether it's escapable
+                // This matches the original regex behavior
+            }
+
+            pos++;
+        }
+
+        // No closing '>' found
+        return null;
     }
 }


### PR DESCRIPTION
発生したStackoverflowを対応いたしました。

追加したテストは、以下の３つです。
- manyUnderscores
- uncompletedHugeHtmlTag
- hugeDataUrlInLink

対応アプローチとしては以下のようにしました。

## manyUnderscores

`-*_` が続く水平線のところで、正規表現で繰り返し判定をしており、長大な１行にされるとスタックを食いつぶすようになってました。こちらはユースケース的にありえないとは思うので制限を入れてもよかったのですが、パターン自体が単純なので、手動でパース処理を書きました。

## uncompletedHugeHtmlTag

HtmlBlockかどうかを判定するロジックの中にあった、XMLのタグかどうかを判定する正規表現で発生。正規表現で抽象化された共通ロジックで処理されていたのと、XMLのタグにそこまでの長い文字列を設定できることにあまり価値がないと見込まれること、XMLのユースケース自体の少なさを見込んで、文字数制限をかけました。

## hugeDataUrlInLink

注釈記法や自動リンクなどでリンクを検知するところで、">"を発見するまでにスタックを食いつぶすほどURLが長かったりすると発生してました。長さ制限などは実質的な解決策にならないのと、検知パターンが単純な正規表現で表現すると無理が出るので、こちらも手動でパース処理を書きました。